### PR TITLE
implemented copy Object

### DIFF
--- a/src/GalerkinToolkit.jl
+++ b/src/GalerkinToolkit.jl
@@ -19,6 +19,7 @@ Object(;kwargs...) = Object(Dict(kwargs))
 Base.propertynames(i::Object) = collect(keys(getfield(i, :item)))
 Base.getproperty(i::Object, x::Symbol) = getindex(getfield(i, :item), x)
 Base.setproperty!(i::Object, name::Symbol, x) = setindex!(getfield(i, :item), x, name)
+Base.copy(i::Object) = Object(getfield(i, :item))
 
 # TODO setproperty instead?
 function setproperties(a::Object;kwargs...)


### PR DESCRIPTION
Copy object will be needed to construct an `m x n` metamaterial since the unit cell mesh will be repeated (and also its coordinated will be translated) `m x n` times (in the 2D metamaterial case).