### PR TITLE
Add "All Tests" for required status check

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -63,6 +63,7 @@ jobs:
             using Pkg
             Pkg.develop(path=".")
             Pkg.test("GalerkinToolkitExamples")'
+
   all_tests:
     name: All Tests and Examples
     runs-on: ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  test:
+  build:
     name: GalerkinToolkit / Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -67,6 +67,10 @@ jobs:
     name: All Tests and Examples
     runs-on: ubuntu-latest
     needs: [test, examples]
+    steps:
+      - name: All test jobs have been successful        
+        run: |
+          echo "All test jobs have been successful"
 
   docs:
     name: Documentation

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -11,7 +11,7 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 jobs:
-  build:
+  test:
     name: GalerkinToolkit / Julia ${{ matrix.version }} - ${{ matrix.os }} - ${{ matrix.arch }} - ${{ github.event_name }}
     runs-on: ${{ matrix.os }}
     strategy:
@@ -63,6 +63,11 @@ jobs:
             using Pkg
             Pkg.develop(path=".")
             Pkg.test("GalerkinToolkitExamples")'
+  all_tests:
+    name: All Tests and Examples
+    runs-on: ubuntu-latest
+    needs: [test, examples]
+
   docs:
     name: Documentation
     runs-on: ubuntu-latest


### PR DESCRIPTION
Fixes #101

There is an issue with selecting specific jobs as required status checks (e.g. for merging to protected branches) when the name is dynamically generated (e.g. due to matrix). Github seems to want the specific name of each job to be provided for every check. I have therefore created a check called "All Tests and Examples" which passes when both the `test` and `examples` job collections pass in their entirety. I have also updated the branch protection rules to require this check to pass.

The results of individual tests on different OS/version/arch are still shown, but the required status is that all of them have passed.