### PR TITLE
Add Zenodo DOI

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -10,6 +10,7 @@ authors:
 
 date-released: 2024-06-07
 version: "0.2.0"
+doi: 10.5281/zenodo.13938389 
 repository-code: "https://github.com/fverdugo/GalerkinToolkit.jl"
 keywords:
   - FEM

--- a/README.md
+++ b/README.md
@@ -4,6 +4,7 @@
 [![Dev](https://img.shields.io/badge/docs-dev-blue.svg)](https://fverdugo.github.io/GalerkinToolkit.jl/dev/)
 [![Build Status](https://github.com/fverdugo/GalerkinToolkit.jl/actions/workflows/CI.yml/badge.svg?branch=main)](https://github.com/fverdugo/GalerkinToolkit.jl/actions/workflows/CI.yml?query=branch%3Amain)
 [![Coverage](https://codecov.io/gh/fverdugo/GalerkinToolkit.jl/branch/main/graph/badge.svg)](https://codecov.io/gh/fverdugo/GalerkinToolkit.jl)
+[![DOI](https://zenodo.org/badge/497260571.svg)](https://doi.org/10.5281/zenodo.13938389)
 
 ## What
 


### PR DESCRIPTION
Now that we have a release for 0.2.1, we have the first release published on Zenodo. This should happen automatically from now on. I have added a badge to the README and put the DOI in the CITATION.cff file.

Fixes #104 