### PR TITLE
Add benchmarking suite with trackable performance

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,7 +3,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,8 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Run benchmark
         run: |
-          cd GalerkinToolkitExamples/benchmarks/
-          julia --project --color=yes -e '
-            using Pkg;
-            Pkg.instantiate();
-            include("run_benchmarks.jl")'
+          julia --project=GalerkinToolkitExamples -e '
+            using Pkg
+            Pkg.develop(path=".")
+            include("GalerkinToolkitExamples/benchmarks/run_benchmarks.jl")'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,3 +45,17 @@ jobs:
             using Pkg
             Pkg.develop(path=".")
             include("GalerkinToolkitExamples/benchmarks/run_benchmarks.jl")'
+
+      - name: Store benchmark result
+        uses: benchmark-action/github-action-benchmark@v1
+        with:
+          name: Julia benchmark result
+          tool: 'julia'
+          output-file-path: output.json
+          # Use personal access token instead of GITHUB_TOKEN due to https://github.community/t/github-action-not-triggering-gh-pages-upon-push/16096
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          auto-push: true
+          # Show alert with commit comment on detecting possible performance regression
+          alert-threshold: '200%'
+          comment-on-alert: true
+          fail-on-alert: true

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -45,4 +45,4 @@ jobs:
           julia --project --color=yes -e '
             using Pkg;
             Pkg.instantiate();
-            include("poisson.jl")'
+            include("run_benchmarks.jl")'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -1,0 +1,47 @@
+name: Performance Regression Tests
+on:
+  push:
+    branches:
+      - main
+
+permissions:
+  contents: write
+  deployments: write
+
+jobs:
+  benchmark:
+    name: Run julia benchmark example
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        version:
+          - '1.10'
+        os:
+          - ubuntu-latest
+        arch:
+          - x64
+    steps:
+      - uses: actions/checkout@v4
+      - uses: julia-actions/setup-julia@v1
+        with:
+          version: ${{ matrix.version }}
+          arch: ${{ matrix.arch }}
+      - uses: actions/cache@v4
+        env:
+          cache-name: cache-artifacts
+        with:
+          path: ~/.julia/artifacts
+          key: runner.os−test−env.cache−name−{{ hashFiles('**/Project.toml') }}
+          restore-keys: |
+            runner.os−test−
+            ${{ env.cache-name }}-
+            ${{ runner.os }}-test-
+            ${{ runner.os }}-
+      - name: Run benchmark
+        run: |
+          cd performance_tests/
+          julia --project --color=yes -e '
+            using Pkg;
+            Pkg.instantiate();
+            include("poisson.jl")'

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 permissions:
   contents: write

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -41,7 +41,7 @@ jobs:
             ${{ runner.os }}-
       - name: Run benchmark
         run: |
-          cd performance_tests/
+          cd GalerkinToolkitExamples/benchmarks/
           julia --project --color=yes -e '
             using Pkg;
             Pkg.instantiate();

--- a/GalerkinToolkitExamples/Project.toml
+++ b/GalerkinToolkitExamples/Project.toml
@@ -20,6 +20,7 @@ SparseArrays = "2f01184e-e22b-5df5-ae63-d93ebab69eaf"
 StaticArrays = "90137ffa-7385-5640-81b9-e52037218182"
 TimerOutputs = "a759f4b9-e2f1-59dc-863e-4aeb61b1ea8f"
 WriteVTK = "64499a7a-5c06-52f2-abe2-ccb03c286192"
+BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 
 [extras]
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -7,7 +7,7 @@ using GalerkinToolkitExamples: Poisson
 
 
 function handwritten_poisson(n)
-	mesh = GT.cartesian_mesh((0,2,0,2),(n,n))
+	mesh = GT.cartesian_mesh((0,2,0,2,0,2),(n,n,n))
 
 	params = Dict{Symbol,Any}()
 	params[:implementation] = :hand_written
@@ -22,7 +22,7 @@ end
 
 suite = BenchmarkGroup()
 suite["poisson"] = BenchmarkGroup(["Poisson", "handwritten"])
-suite["poisson"]["n=150"] = @benchmarkable handwritten_poisson(150)
+suite["poisson"]["n=150"] = @benchmarkable handwritten_poisson(10)
 
 tune!(suite)
 

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -20,13 +20,12 @@ function handwritten_poisson(n)
 	Poisson.main(params)
 end
 
-
 suite = BenchmarkGroup()
-suite["poisson"] = BenchmarkGroup(["tag1", "tag2"])
-suite["poisson"][2] = @benchmarkable handwritten_poisson(2)
-suite["poisson"][3] = @benchmarkable handwritten_poisson(3)
+suite["poisson"] = BenchmarkGroup(["Poisson", "handwritten"])
+suite["poisson"]["n=200"] = @benchmarkable handwritten_poisson(200)
 
 tune!(suite)
+
 results = run(suite, verbose = true)
 
 BenchmarkTools.save("output.json", median(results))

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -20,26 +20,9 @@ function handwritten_poisson(n)
 	Poisson.main(params)
 end
 
-function automatic_poisson(n)
-	mesh = GT.cartesian_mesh((0,2,0,2,0,2), (n,n,n))
-
-	params = Dict{Symbol,Any}()
-	params[:implementation] = :automatic
-	params[:mesh] = mesh
-	params[:dirichlet_tags] = ["1-face-1","1-face-2","1-face-3","1-face-4"]
-	params[:discretization_method] = :continuous_galerkin
-	params[:dirichlet_method] = :strong
-	params[:integration_degree] = 2
-
-	Poisson.main(params)
-end
-
 suite = BenchmarkGroup()
 suite["poisson-hand"] = BenchmarkGroup(["Poisson", "handwritten"])
 suite["poisson-hand"]["n=10"] = @benchmarkable handwritten_poisson(10)
-
-suite["poisson-auto"] = BenchmarkGroup(["Poisson", "automatic"])
-suite["poisson-auto"]["n=10"] = @benchmarkable automatic_poisson(10)
 
 tune!(suite)
 

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -28,7 +28,7 @@ end
 
 # Build a benchmark suite for the Poisson example
 suite = BenchmarkGroup()
-suite["poisson-hand"] = BenchmarkGroup(["Poisson", "handwritten"])
+suite["poisson-hand"] = BenchmarkGroup(["Poisson", "handwritten", "3D"])
 suite["poisson-hand"]["n=10"] = @benchmarkable handwritten_poisson(10)
 
 # Run all benchmarks

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -22,7 +22,7 @@ end
 
 suite = BenchmarkGroup()
 suite["poisson"] = BenchmarkGroup(["Poisson", "handwritten"])
-suite["poisson"]["n=200"] = @benchmarkable handwritten_poisson(200)
+suite["poisson"]["n=150"] = @benchmarkable handwritten_poisson(150)
 
 tune!(suite)
 

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -1,0 +1,34 @@
+module GalerkinToolkitBenchmarkTests
+
+using BenchmarkTools
+
+import GalerkinToolkit as GT
+using GalerkinToolkitExamples: Poisson
+
+
+function handwritten_poisson(n)
+	mesh = GT.cartesian_mesh((0,2,0,2),(n,n))
+
+	params = Dict{Symbol,Any}()
+	params[:implementation] = :hand_written
+	params[:mesh] = mesh
+	params[:dirichlet_tags] = ["1-face-1","1-face-2","1-face-3","1-face-4"]
+	params[:discretization_method] = :continuous_galerkin
+	params[:dirichlet_method] = :strong
+	params[:integration_degree] = 2
+
+	Poisson.main(params)
+end
+
+
+suite = BenchmarkGroup()
+suite["poisson"] = BenchmarkGroup(["tag1", "tag2"])
+suite["poisson"][2] = @benchmarkable handwritten_poisson(2)
+suite["poisson"][3] = @benchmarkable handwritten_poisson(3)
+
+tune!(suite)
+results = run(suite, verbose = true)
+
+BenchmarkTools.save("output.json", median(results))
+
+end # module

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -7,6 +7,11 @@ using GalerkinToolkitExamples: Poisson
 
 
 function handwritten_poisson(n)
+	"""
+	Runs the hand-written Poisson example code, for a 3D
+	mesh of dimensions n x n x n.
+	"""
+
 	mesh = GT.cartesian_mesh((0,2,0,2,0,2), (n,n,n))
 
 	params = Dict{Symbol,Any}()
@@ -20,14 +25,17 @@ function handwritten_poisson(n)
 	Poisson.main(params)
 end
 
+
+# Build a benchmark suite for the Poisson example
 suite = BenchmarkGroup()
 suite["poisson-hand"] = BenchmarkGroup(["Poisson", "handwritten"])
 suite["poisson-hand"]["n=10"] = @benchmarkable handwritten_poisson(10)
 
+# Run all benchmarks
 tune!(suite)
-
 results = run(suite, verbose = true)
 
+# Save benchmark results for tracking and visualization
 BenchmarkTools.save("output.json", median(results))
 
 end # module

--- a/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
+++ b/GalerkinToolkitExamples/benchmarks/run_benchmarks.jl
@@ -7,7 +7,7 @@ using GalerkinToolkitExamples: Poisson
 
 
 function handwritten_poisson(n)
-	mesh = GT.cartesian_mesh((0,2,0,2,0,2),(n,n,n))
+	mesh = GT.cartesian_mesh((0,2,0,2,0,2), (n,n,n))
 
 	params = Dict{Symbol,Any}()
 	params[:implementation] = :hand_written
@@ -20,9 +20,26 @@ function handwritten_poisson(n)
 	Poisson.main(params)
 end
 
+function automatic_poisson(n)
+	mesh = GT.cartesian_mesh((0,2,0,2,0,2), (n,n,n))
+
+	params = Dict{Symbol,Any}()
+	params[:implementation] = :automatic
+	params[:mesh] = mesh
+	params[:dirichlet_tags] = ["1-face-1","1-face-2","1-face-3","1-face-4"]
+	params[:discretization_method] = :continuous_galerkin
+	params[:dirichlet_method] = :strong
+	params[:integration_degree] = 2
+
+	Poisson.main(params)
+end
+
 suite = BenchmarkGroup()
-suite["poisson"] = BenchmarkGroup(["Poisson", "handwritten"])
-suite["poisson"]["n=150"] = @benchmarkable handwritten_poisson(10)
+suite["poisson-hand"] = BenchmarkGroup(["Poisson", "handwritten"])
+suite["poisson-hand"]["n=10"] = @benchmarkable handwritten_poisson(10)
+
+suite["poisson-auto"] = BenchmarkGroup(["Poisson", "automatic"])
+suite["poisson-auto"]["n=10"] = @benchmarkable automatic_poisson(10)
 
 tune!(suite)
 

--- a/docs/src/developers_guide.md
+++ b/docs/src/developers_guide.md
@@ -5,4 +5,6 @@ There is a benchmark suite defined in `GalerkinToolkitExamples/benchmarks`. This
 and [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) to collect the results and store them in the `gh-pages` branch. Graphs of performance
 changes over time (per commit hash) can be viewed here: <https://galerkintoolkit.github.io/GalerkinToolkit.jl/dev/bench/>.
 
+The github action can be configured (in `.github/workflows/benchmarks.yml`) to fail if the performance change is beyond a given threshold. Look for the `alert-threshold:` and `fail-on-alert:` keys.
+
 More benchmarks can be added (or existing ones modified) in `GalerkinToolkitExamples/benchmarks/run_benchmarks.jl`.

--- a/docs/src/developers_guide.md
+++ b/docs/src/developers_guide.md
@@ -1,3 +1,8 @@
 # Developers guide
 
+## Performance Benchmarks
+There is a benchmark suite defined in `GalerkinToolkitExamples/benchmarks`. This uses [BenchmarkTools.jl](https://github.com/JuliaCI/BenchmarkTools.jl) to perform the timings
+and [github-action-benchmark](https://github.com/benchmark-action/github-action-benchmark) to collect the results and store them in the `gh-pages` branch. Graphs of performance
+changes over time (per commit hash) can be viewed here: <https://galerkintoolkit.github.io/GalerkinToolkit.jl/dev/bench/>.
 
+More benchmarks can be added (or existing ones modified) in `GalerkinToolkitExamples/benchmarks/run_benchmarks.jl`.


### PR DESCRIPTION
Fixes #148 

This PR adds a benchmarking suite with plots of performance changes over time (per commit hash) stored in the gh-pages branch using the <https://github.com/benchmark-action/github-action-benchmark> github action.

Currently, the benchmarks are in their own directory in `GalerkinToolkitExamples`. This is in order to benchmark example code (such as the hand-written Poisson example) which we will optimize first.

However, we may later choose to split off the benchmarks into their own subpackage if that is cleaner (or if we have benchmarks that are not related to the examples). We can decide together what we want to be in there.

The benchmark results are collected and stored in the `gh-pages` branch, in `dev/bench/`. You can see the generated graphs of performance changes here: <https://galerkintoolkit.github.io/GalerkinToolkit.jl/dev/bench/>

You might need to scroll down a bit to see the `poisson-hand/n=10` benchmark which has more data. The others were earlier tests and only have one data point.

I have added some developer documentation about the benchmarking.