### PR TITLE
Fix from profiling

### DIFF
--- a/GalerkinToolkitExamples/src/poisson.jl
+++ b/GalerkinToolkitExamples/src/poisson.jl
@@ -297,7 +297,7 @@ function main_hand_written(params)
     T = Float64
     Tgrad = SVector{D,T}
     Tx = Tgrad
-    TJ = SMatrix{D,D,T}
+    TJ = typeof(zero(Tx)*transpose(zero(Tx)))
 
     @timeit timer "cache_quantities" begin
         rid_to_cache = map(rid_to_reffe,rid_to_refface,rid_to_refquad) do reffe,refface,refquad

--- a/GalerkinToolkitExamples/src/poisson.jl
+++ b/GalerkinToolkitExamples/src/poisson.jl
@@ -190,41 +190,72 @@ function main_hand_written(params)
 
     mesh = params[:mesh]
     D = GT.num_dims(mesh)
+
+    # Set computational domains
     Ω = GT.interior(mesh,physical_names=params[:domain_tags])
     Γd = GT.boundary(mesh;physical_names=params[:dirichlet_tags])
+    
     interpolation_degree = params[:interpolation_degree]
     integration_degree = params[:integration_degree]
+
+    # Set up numerical quadratures
     dΩ = GT.measure(Ω,integration_degree)
+
     u = params[:u]
     f(x) = -laplacian(u,x)
 
+    # Set interpolation space -> Lagrange polynomial basis function, the element type and geometry
     V = GT.lagrange_space(Ω,interpolation_degree;dirichlet_boundary=Γd)
+
+    # Initializing DiscreteField with zero interior and boundary values
     uh = GT.zero_field(Float64,V)
 
+    # Extract uh values associated with out-of-the-boundary nodes
     x_free = GT.free_values(uh)
+    # Extract uh values associated with nodes at boundary
     x_diri = GT.dirichlet_values(uh)
+
+    # Calculate faces degrees of freedom (dofs) -> negative dofs are associated with nodes at boundary
     face_to_dofs = GT.face_dofs(V)
+
+    # Get node coordinates in the computational FE space
     vnode_to_coord = GT.node_coordinates(V)
+
+    # Calculate degree of freedom for each boundary node in the FE space
     diri_dof_to_vnode = GT.dirichlet_dof_node(V)
+
+    # Calculate the value of the guess u function at each boundary node
     x_diri .= u.(vnode_to_coord[diri_dof_to_vnode])
 
+    # Describe interpolation between nodes
     rid_to_reffe = GT.reference_fes(V)
     face_to_rid = GT.face_reference_id(V)
+
+    # rid_to_refquad -> `Cuadrature`
     rid_to_refquad = GT.reference_quadratures(dΩ)
 
+    # Gather node indexes of each face
     cell_to_nodes = GT.face_nodes(mesh,D)
+    
+    # Get node coordinates in the mesh
     node_to_coords = GT.node_coordinates(mesh)
+    
+    # rid_to_refface -> GenericLagrangeMeshFace
     rid_to_refface = GT.reference_faces(mesh,D)
     cell_to_rid = GT.face_reference_id(mesh,D)
     face_to_cell = GT.faces(Ω)
     nfaces = length(face_to_cell)
 
+    # Returns a series of callables containing recipes on how to build the matrix and vector
     # TODO the strategies need some refactoring
     matrix_strategy =  GT.monolithic_matrix_assembly_strategy()
     vector_strategy = GT.monolithic_vector_assembly_strategy()
 
+    # Consider only interpolation points which are not in the boundary
     free_dofs = GT.free_dofs(V)
     T = Float64
+
+    # Initialize stiffness matrix and load vector
     matrix_strategy_init = matrix_strategy.init(free_dofs,free_dofs,T)
     vector_strategy_init = vector_strategy.init(free_dofs,T)
     field_i = field_j = 1
@@ -232,19 +263,23 @@ function main_hand_written(params)
     # Count
     matrix_strategy_counter = matrix_strategy.counter(matrix_strategy_init)
     vector_strategy_counter = vector_strategy.counter(vector_strategy_init)
-    for face in 1:nfaces
-        dofs = face_to_dofs[face]
-        for dof_i in dofs
-            vector_strategy_counter =
-            vector_strategy.count(vector_strategy_counter,
-                                  vector_strategy_init,
-                                  dof_i,field_i)
-            for dof_j in dofs
-                matrix_strategy_counter =
-                matrix_strategy.count(
-                                      matrix_strategy_counter,
-                                      matrix_strategy_init,
-                                      dof_i,dof_j,field_i,field_j)
+
+    # Count the number of terms in the matrix -> important for defining storage sparse matrix format later
+    @timeit timer "count_terms" begin
+        for face in 1:nfaces
+            dofs = face_to_dofs[face]
+            for dof_i in dofs
+                vector_strategy_counter =
+                vector_strategy.count(vector_strategy_counter,
+                                      vector_strategy_init,
+                                      dof_i,field_i)
+                for dof_j in dofs
+                    matrix_strategy_counter =
+                    matrix_strategy.count(
+                                          matrix_strategy_counter,
+                                          matrix_strategy_init,
+                                          dof_i,dof_j,field_i,field_j)
+                end
             end
         end
     end
@@ -263,90 +298,120 @@ function main_hand_written(params)
     Tgrad = SVector{D,T}
     Tx = Tgrad
     TJ = SMatrix{D,D,T}
-    rid_to_cache = map(rid_to_reffe,rid_to_refface,rid_to_refquad) do reffe,refface,refquad
-        ndofs = GT.num_dofs(reffe)
-        A = zeros(T,ndofs,ndofs)
-        b = zeros(T,ndofs)
-        ue = zeros(T,ndofs)
-        x = GT.coordinates(refquad)
-        ref_grads = GT.tabulator(reffe)(ForwardDiff.gradient,x)
-        ref_vals = GT.tabulator(reffe)(GT.value,x)
-        ref_vals_geom = GT.tabulator(refface)(GT.value,x)
-        ref_grads_geom = GT.tabulator(refface)(ForwardDiff.gradient,x)
-        phys_grads = zeros(Tgrad,ndofs)
-        npoints = length(x)
-        weights = GT.weights(refquad)
-        (;A,b,ue,ref_vals_geom,ref_grads_geom,phys_grads,ref_vals,ref_grads,npoints,ndofs,weights)
+
+    @timeit timer "cache_quantities" begin
+        rid_to_cache = map(rid_to_reffe,rid_to_refface,rid_to_refquad) do reffe,refface,refquad
+            
+            # Set matrix and vector dimensions as the number of out-of-boundary nodes in the reference FE space
+            ndofs = GT.num_dofs(reffe)
+
+            A = zeros(T,ndofs,ndofs)
+            b = zeros(T,ndofs)
+            ue = zeros(T,ndofs)
+
+            # Get the quadrature points
+            x = GT.coordinates(refquad)
+
+            # Calculate the gradient of the basis functions at the quadrature points
+            ref_grads = GT.tabulator(reffe)(ForwardDiff.gradient,x)
+
+            # Calculate the value of the basis functions at the quadrature points
+            ref_vals = GT.tabulator(reffe)(GT.value,x)
+
+            # Evaluate the values and gradients of basis functions for the mesh
+            ref_vals_geom = GT.tabulator(refface)(GT.value,x)
+            ref_grads_geom = GT.tabulator(refface)(ForwardDiff.gradient,x)
+
+            phys_grads = zeros(Tgrad,ndofs)
+            npoints = length(x)
+            weights = GT.weights(refquad)
+            (;A,b,ue,ref_vals_geom,ref_grads_geom,phys_grads,ref_vals,ref_grads,npoints,ndofs,weights)
+        end
     end
-    
+
     # Fill
     matrix_strategy_counter = matrix_strategy.counter(matrix_strategy_init)
     vector_strategy_counter = vector_strategy.counter(vector_strategy_init)
     z = zero(T)
-    for face in 1:nfaces
-        rid = face_to_rid[face]
-        cache = rid_to_cache[rid]
-        dofs = face_to_dofs[face]
-        cell = face_to_cell[face]
-        nodes = cell_to_nodes[cell]
-        fill!(cache.A,z)
-        fill!(cache.b,z)
-        fill!(cache.ue,z)
-        ndofs = cache.ndofs
-        # Fill in Dirichlet values
-        for i in 1:ndofs
-            dof = dofs[i]
-            if dof < 0
-                cache.ue[i] = x_diri[-dof]
-            end
-        end
-        # Integration loop
-        for point in 1:cache.npoints
-            # Compute integration coordinate and Jacobian transpose
-            x = zero(Tx)
-            Jt = zero(TJ)
-            for (inode,node) in enumerate(nodes)
-                coords = node_to_coords[node]
-                x += cache.ref_vals_geom[point,inode]*coords
-                Jt += coords*transpose(cache.ref_grads_geom[point,inode])
-            end
-            # Integration weight
-            dV = abs(det(Jt))*cache.weights[point]
-            # Compute physical gradients
-            invJt = inv(Jt)
+
+    # Calculate matrix and vector for each face first and then summed over the terms of all faces
+    @timeit timer "fill_and_assembly" begin
+        for face in 1:nfaces
+            rid = face_to_rid[face]
+            cache = rid_to_cache[rid]
+            
+            # Face degrees of freedom
+            dofs = face_to_dofs[face]
+
+            # Set face index
+            cell = face_to_cell[face]
+            
+            # Definition of the face in terms of node ids
+            nodes = cell_to_nodes[cell]
+
+            fill!(cache.A,z)
+            fill!(cache.b,z)
+            fill!(cache.ue,z)
+
+            ndofs = cache.ndofs
+            
+            # Fill in Dirichlet values
+            # Use face dofs to assign the initial values of uh at the boundary
             for i in 1:ndofs
-                cache.phys_grads[i] = invJt*cache.ref_grads[point,i]
+                dof = dofs[i]
+                if dof < 0
+                    cache.ue[i] = x_diri[-dof]
+                end
             end
-            # Integrate matrix and vector
-            fx = f(x)
-            for i in 1:ndofs
-                cache.b[i] += cache.ref_vals[i]*fx*dV
-                for j in 1:ndofs
-                    Aij = cache.phys_grads[i]⋅cache.phys_grads[j]*dV
-                    cache.A[i,j] += Aij
-                    cache.b[i] -= Aij*cache.ue[j]
+
+            # Integration loop
+            for point in 1:cache.npoints  #-> loop over quadrature points
+                # Compute integration coordinate and Jacobian transpose
+                x = zero(Tx)
+                Jt = zero(TJ)
+                for (inode,node) in enumerate(nodes)
+                    coords = node_to_coords[node]
+                    x += cache.ref_vals_geom[point,inode]*coords
+                    Jt += coords*transpose(cache.ref_grads_geom[point,inode])
+                end
+                # Integration weight
+                dV = abs(det(Jt))*cache.weights[point]
+                # Compute physical gradients
+                invJt = inv(Jt)
+                for i in 1:ndofs
+                    cache.phys_grads[i] = invJt*cache.ref_grads[point,i]
+                end
+                # Integrate matrix and vector
+                fx = f(x)
+                for i in 1:ndofs
+                    cache.b[i] += cache.ref_vals[i]*fx*dV
+                    for j in 1:ndofs
+                        Aij = cache.phys_grads[i]⋅cache.phys_grads[j]*dV
+                        cache.A[i,j] += Aij
+                        cache.b[i] -= Aij*cache.ue[j]
+                    end
+                end
+            end
+            # Assemble the matrix and vector
+            for (i,dof_i) in enumerate(dofs)
+                vector_strategy_counter =
+                vector_strategy.set!(vector_strategy_alloc,
+                                     vector_strategy_counter,
+                                     vector_strategy_init,
+                                     cache.b[i],
+                                     dof_i,field_i)
+                for (j,dof_j) in enumerate(dofs)
+                    matrix_strategy_counter =
+                    matrix_strategy.set!(matrix_strategy_alloc,
+                                         matrix_strategy_counter,
+                                         matrix_strategy_init,
+                                         cache.A[i,j],
+                                         dof_i,dof_j,field_i,field_j)
                 end
             end
         end
-        # Assemble the matrix and vector
-        for (i,dof_i) in enumerate(dofs)
-            vector_strategy_counter =
-            vector_strategy.set!(vector_strategy_alloc,
-                                 vector_strategy_counter,
-                                 vector_strategy_init,
-                                 cache.b[i],
-                                 dof_i,field_i)
-            for (j,dof_j) in enumerate(dofs)
-                matrix_strategy_counter =
-                matrix_strategy.set!(matrix_strategy_alloc,
-                                     matrix_strategy_counter,
-                                     matrix_strategy_init,
-                                     cache.A[i,j],
-                                     dof_i,dof_j,field_i,field_j)
-            end
-        end
-    end
 
+    end
     # Build the linear system and solve it
     # TODO do not return rhs_cache, and matrix_cache by default
     rhs, rhs_cache = vector_strategy.compress(vector_strategy_alloc,vector_strategy_init)
@@ -364,56 +429,61 @@ function main_hand_written(params)
     # Integrate error norms
     el2 = zero(T)
     eh1 = zero(T)
-    for face in 1:nfaces
-        rid = face_to_rid[face]
-        cache = rid_to_cache[rid]
-        dofs = face_to_dofs[face]
-        cell = face_to_cell[face]
-        nodes = cell_to_nodes[cell]
-        ndofs = cache.ndofs
-        # Fill values
-        for i in 1:ndofs
-            dof = dofs[i]
-            if dof < 0
-                cache.ue[i] = x_diri[-dof]
-            else
-                cache.ue[i] = x_free[dof]
+
+    @timeit timer "error_norms" begin
+        for face in 1:nfaces
+            rid = face_to_rid[face]
+            cache = rid_to_cache[rid]
+            dofs = face_to_dofs[face]
+            cell = face_to_cell[face]
+            nodes = cell_to_nodes[cell]
+            ndofs = cache.ndofs
+            # Fill values
+            for i in 1:ndofs
+                dof = dofs[i]
+                if dof < 0
+                    cache.ue[i] = x_diri[-dof]
+                else
+                    cache.ue[i] = x_free[dof]
+                end
+            end
+            # Integration loop
+            for point in 1:cache.npoints
+                # Compute integration coordinate and Jacobian transpose
+                x = zero(Tx)
+                Jt = zero(TJ)
+                for (inode,node) in enumerate(nodes)
+                    coords = node_to_coords[node]
+                    x += cache.ref_vals_geom[point,inode]*coords
+                    Jt += coords*transpose(cache.ref_grads_geom[point,inode])
+                end
+                # Integration weight
+                dV = abs(det(Jt))*cache.weights[point]
+                # Compute physical gradients
+                invJt = inv(Jt)
+                for i in 1:ndofs
+                    cache.phys_grads[i] = invJt*cache.ref_grads[point,i]
+                end
+                # Compute FE solution and its gradients
+                uhx = z
+                ∇uhx = zero(Tx)
+                for i in 1:ndofs
+                    ui = cache.ue[i]
+                    uhx += cache.ref_vals[point,i]*ui
+                    ∇uhx += cache.phys_grads[i]*ui
+                end
+                # Compute and integrate the error
+                ex = u(x)-uhx
+                ∇ex = ForwardDiff.gradient(u,x)-∇uhx
+                el2 += ex*ex*dV
+                eh1 += ∇ex⋅∇ex*dV
             end
         end
-        # Integration loop
-        for point in 1:cache.npoints
-            # Compute integration coordinate and Jacobian transpose
-            x = zero(Tx)
-            Jt = zero(TJ)
-            for (inode,node) in enumerate(nodes)
-                coords = node_to_coords[node]
-                x += cache.ref_vals_geom[point,inode]*coords
-                Jt += coords*transpose(cache.ref_grads_geom[point,inode])
-            end
-            # Integration weight
-            dV = abs(det(Jt))*cache.weights[point]
-            # Compute physical gradients
-            invJt = inv(Jt)
-            for i in 1:ndofs
-                cache.phys_grads[i] = invJt*cache.ref_grads[point,i]
-            end
-            # Compute FE solution and its gradients
-            uhx = z
-            ∇uhx = zero(Tx)
-            for i in 1:ndofs
-                ui = cache.ue[i]
-                uhx += cache.ref_vals[point,i]*ui
-                ∇uhx += cache.phys_grads[i]*ui
-            end
-            # Compute and integrate the error
-            ex = u(x)-uhx
-            ∇ex = ForwardDiff.gradient(u,x)-∇uhx
-            el2 += ex*ex*dV
-            eh1 += ∇ex⋅∇ex*dV
-        end
+
+        el2 = sqrt(el2)
+        eh1 = sqrt(eh1)
+
     end
-    el2 = sqrt(el2)
-    eh1 = sqrt(eh1)
     results[:error_h1_norm] = eh1
     results[:error_l2_norm] = el2
 

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -307,6 +307,10 @@ end
 
 abstract type AbstractSpace <: GT.AbstractType end
 
+function space_cache(;kwargs...)
+    (;kwargs...)
+end
+
 Base.iterate(m::AbstractSpace) = iterate(components(m))
 Base.iterate(m::AbstractSpace,state) = iterate(components(m),state)
 Base.getindex(m::AbstractSpace,field::Integer) = component(m,field)
@@ -844,6 +848,9 @@ function reference_face_own_dof_permutations(space::AbstractSpace,d)
 end
 
 function face_dofs(space::AbstractSpace)
+    if space.cache !== nothing
+        return space.cache.face_dofs
+    end
     state = generate_dof_ids(space)
     state.cell_to_dofs # TODO rename face_dofs ?
 end
@@ -1518,13 +1525,32 @@ end
 # This space is not suitable for assembling problems in general, as there might be gaps in the dofs
 
 function iso_parametric_space(dom::ReferenceDomain;
-        dirichlet_boundary=nothing)
-    IsoParametricSpace(dom,dirichlet_boundary)
+        dirichlet_boundary=nothing,
+        cache=nothing)
+    IsoParametricSpace(dom,dirichlet_boundary,cache) |> setup_space
 end
 
-struct IsoParametricSpace{A,B} <: AbstractSpace
+struct IsoParametricSpace{A,B,C} <: AbstractSpace
     domain::A
     dirichlet_boundary::B
+    cache::C
+end
+
+function setup_space(V::IsoParametricSpace)
+    if V.cache !== nothing
+        return V
+    end
+    face_dofs = GT.face_dofs(V)
+    cache = space_cache(;face_dofs)
+    replace_cache(V,cache)
+end
+
+function replace_cache(V::IsoParametricSpace,cache)
+    GT.iso_parametric_space(
+        V.domain;
+        V.dirichlet_boundary,
+        cache
+    )
 end
 
 function free_and_dirichlet_nodes(V::IsoParametricSpace)
@@ -1555,6 +1581,9 @@ function dirichlet_dof_location(V::IsoParametricSpace)
 end
 
 function face_dofs(V::IsoParametricSpace)
+    if V.cache !== nothing
+        return V.cache.face_dofs
+    end
     face_dofs(V,V.dirichlet_boundary)
 end
 
@@ -1609,7 +1638,9 @@ function lagrange_space(domain,order;
     dirichlet_boundary=nothing,
     space=nothing,
     major=:component,
-    shape=SCALAR_SHAPE)
+    shape=SCALAR_SHAPE,
+    cache=nothing,
+    )
 
     @assert conformity in (:default,:L2)
 
@@ -1620,11 +1651,34 @@ function lagrange_space(domain,order;
                   dirichlet_boundary,
                   space,
                   major,
-                  shape)
+                  shape,
+                  cache) |> setup_space
 
 end
 
-struct LagrangeSpace{A,B,C,F,G,H} <: AbstractSpace
+function setup_space(space::AbstractSpace)
+    if space.cache !== nothing
+        return space
+    end
+    face_dofs = GT.face_dofs(space)
+    cache = space_cache(;face_dofs)
+    replace_cache(space,cache)
+end
+
+function replace_cache(space::AbstractSpace,cache)
+    GT.lagrange_space(
+        space.domain,
+        space.order;
+        space.conformity,
+        space.dirichlet_boundary,
+        space.space,
+        space.major,
+        space.shape,
+        cache
+    )
+end
+
+struct LagrangeSpace{A,B,C,F,G,H,I} <: AbstractSpace
     domain::A
     order::B
     conformity::Symbol
@@ -1632,12 +1686,14 @@ struct LagrangeSpace{A,B,C,F,G,H} <: AbstractSpace
     space::F # TODO rename this one?
     major::G
     shape::H
+    cache::I
 end
 
 function face_nodes(a::LagrangeSpace)
     major = :component
     shape = SCALAR_SHAPE
     dirichlet_boundary = nothing
+    cache = nothing
     V = LagrangeSpace(
                       a.domain,
                       a.order,
@@ -1645,7 +1701,8 @@ function face_nodes(a::LagrangeSpace)
                       dirichlet_boundary,
                       a.space,
                       major,
-                      shape
+                      shape,
+                      cache,
                      )
     face_dofs(V)
 end
@@ -1654,6 +1711,7 @@ function node_coordinates(a::LagrangeSpace)
     major = :component
     shape = SCALAR_SHAPE
     dirichlet_boundary = nothing
+    cache = nothing
     V = LagrangeSpace(
                       a.domain,
                       a.order,
@@ -1661,7 +1719,8 @@ function node_coordinates(a::LagrangeSpace)
                       dirichlet_boundary,
                       a.space,
                       major,
-                      shape
+                      shape,
+                      cache,
                      )
     vrid_to_reffe = reference_fes(V)
     vface_to_vrid = face_reference_id(V)
@@ -1723,6 +1782,7 @@ function free_and_dirichlet_dof_node(space::LagrangeSpace)
     major = :component
     shape = SCALAR_SHAPE
     dirichlet_boundary = nothing
+    cache = nothing
     V = LagrangeSpace(
                       space.domain,
                       space.order,
@@ -1730,7 +1790,8 @@ function free_and_dirichlet_dof_node(space::LagrangeSpace)
                       dirichlet_boundary,
                       space.space,
                       major,
-                      shape
+                      shape,
+                      cache,
                      )
     face_to_nodes = GT.face_dofs(V)
     face_to_dofs = GT.face_dofs(space)

--- a/src/interpolation.jl
+++ b/src/interpolation.jl
@@ -1656,7 +1656,18 @@ function lagrange_space(domain,order;
 
 end
 
-function setup_space(space::AbstractSpace)
+struct LagrangeSpace{A,B,C,F,G,H,I} <: AbstractSpace
+    domain::A
+    order::B
+    conformity::Symbol
+    dirichlet_boundary::C
+    space::F # TODO rename this one?
+    major::G
+    shape::H
+    cache::I
+end
+
+function setup_space(space::LagrangeSpace)
     if space.cache !== nothing
         return space
     end
@@ -1665,7 +1676,7 @@ function setup_space(space::AbstractSpace)
     replace_cache(space,cache)
 end
 
-function replace_cache(space::AbstractSpace,cache)
+function replace_cache(space::LagrangeSpace,cache)
     GT.lagrange_space(
         space.domain,
         space.order;
@@ -1676,17 +1687,6 @@ function replace_cache(space::AbstractSpace,cache)
         space.shape,
         cache
     )
-end
-
-struct LagrangeSpace{A,B,C,F,G,H,I} <: AbstractSpace
-    domain::A
-    order::B
-    conformity::Symbol
-    dirichlet_boundary::C
-    space::F # TODO rename this one?
-    major::G
-    shape::H
-    cache::I
 end
 
 function face_nodes(a::LagrangeSpace)

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -377,20 +377,18 @@ function default_space(geom)
     end
 end
 
-function node_coordinates_from_monomials_exponents(monomial_exponents,order_per_dir,real_type)
-    D = length(order_per_dir)
-    Tv = real_type
+function node_coordinates_from_monomials_exponents(monomial_exponents,order_per_dir,::Type{Tv}) where Tv
     if length(monomial_exponents) == 0
-        return  
+        return SVector{length(order_per_dir),Tv}[]
     end
     node_coordinates = map(monomial_exponents) do exponent
         map(exponent,order_per_dir) do e,order
             if order != 0
-                real_type(e/order)
+               Tv(e/order)
             else
-                real_type(e)
+               Tv(e)
             end
-        end |> SVector{D,Tv}
+        end |> SVector{length(order_per_dir),Tv}
     end
 end
 
@@ -404,13 +402,12 @@ function monomial_exponents_from_space(space,args...)
     end
 end
 
-function monomial_exponents_from_filter(f,order_per_dir,int_type)
-    Ti = int_type
+function monomial_exponents_from_filter(f,order_per_dir,::Type{Ti}) where Ti
     terms_per_dir = Tuple(map(d->d+1,order_per_dir))
     D = length(terms_per_dir)
     cis = CartesianIndices(terms_per_dir)
-    m = count(ci->f(SVector{D,Ti}(Tuple(ci) .- 1),order_per_dir),cis)
-    result = zeros(SVector{D,int_type},m)
+    m = count(ci->f(SVector{length(terms_per_dir),Ti}(Tuple(ci) .- 1),order_per_dir),cis)
+    result = zeros(SVector{D,Ti},m)
     li = 0
     for ci in cis
         t = SVector{D,Ti}(Tuple(ci) .- 1)

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1519,7 +1519,7 @@ function intersection!(a,b,na,nb)
   end
 end
 
-function find_eq(v::T, b::AbstractVector{T}) where T
+function find_eq(v,b)
     for vs in b
         if v == vs
             return true
@@ -1528,24 +1528,24 @@ function find_eq(v::T, b::AbstractVector{T}) where T
     return false
 end
 
-function is_subset(a::AbstractVector{T}, b::AbstractVector{T}) where T
+function is_subset(a,b)
     for i in 1:length(a)
         v = a[i]
-        if v == convert(T, INVALID_ID)
+        if v == INVALID_ID
             continue
         end
-        if !find_eq(v, b)
+        if !find_eq(v,b)
             return false
         end
     end
     return true
 end
 
-function same_valid_ids(a::AbstractVector{T}, b::AbstractVector{T}) where T
-    if !is_subset(a, b)
+function same_valid_ids(a,b)
+    if !is_subset(a,b)
         return false
     end
-    if !is_subset(b, a)
+    if !is_subset(b,a)
         return false
     end
     return true

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1384,7 +1384,7 @@ function fill_face_boundary_mesh_topology!(topo,mesh,D,d)
                     dfaces = vertex_to_dfaces[vertex]
                     for dface1 in dfaces
                         vertices1 = dface_to_vertices[dface1]
-                        if same_valid_ids(vertices,vertices1)
+                        if same_valid_ids(collect(vertices),collect(vertices1))
                             dface2 = dface1
                             break
                         end
@@ -1518,31 +1518,36 @@ function intersection!(a,b,na,nb)
   end
 end
 
-function same_valid_ids(a,b)
-  function is_subset(a,b)
-    for i in 1:length(a)
-      v = a[i]
-      if v == INVALID_ID
-        continue
-      end
-      c = find_eq(v,b)
-      if c == false; return false; end
-    end
-    return true
-  end
-  function find_eq(v,b)
+function find_eq(v::T, b::Vector{T}) where T
     for vs in b
-      if v == vs
-        return true
-      end
+        if v == vs
+            return true
+        end
     end
     return false
-  end
-  c = is_subset(a,b)
-  if c == false; return false; end
-  c = is_subset(b,a)
-  if c == false; return false; end
-  return true
+end
+
+function is_subset(a::Vector{T}, b::Vector{T}) where T
+    for i in 1:length(a)
+        v = a[i]
+        if v == convert(T, INVALID_ID)
+            continue
+        end
+        if !find_eq(v, b)
+            return false
+        end
+    end
+    return true
+end
+
+function same_valid_ids(a::Vector{T}, b::Vector{T}) where T
+    if !is_subset(a, b)
+        return false
+    end
+    if !is_subset(b, a)
+        return false
+    end
+    return true
 end
 
 ## TODO AbstractFaceTopology <: AbstractMeshTopology
@@ -1892,7 +1897,7 @@ function generate_face_boundary(
                 dfaces = vertex_to_dfaces[vertex]
                 for dface1 in dfaces
                     vertices1 = dface_to_vertices[dface1]
-                    if same_valid_ids(vertices,vertices1)
+                    if same_valid_ids(collect(vertices),collect(vertices1))
                         dface2 = dface1
                         break
                     end
@@ -1927,7 +1932,7 @@ function generate_face_boundary(
                     ldface2 = Int32(INVALID_ID)
                     for (ldface1,lvertices1) in enumerate(ldface1_to_lvertices1)
                         vertices1 = view(lvertex1_to_vertex1,lvertices1)
-                        if same_valid_ids(vertices,vertices1)
+                        if same_valid_ids(collect(vertices),collect(vertices1))
                             ldface2 = ldface1
                             break
                         end

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -1385,7 +1385,7 @@ function fill_face_boundary_mesh_topology!(topo,mesh,D,d)
                     dfaces = vertex_to_dfaces[vertex]
                     for dface1 in dfaces
                         vertices1 = dface_to_vertices[dface1]
-                        if same_valid_ids(collect(vertices),collect(vertices1))
+                        if same_valid_ids(vertices,vertices1)
                             dface2 = dface1
                             break
                         end
@@ -1519,7 +1519,7 @@ function intersection!(a,b,na,nb)
   end
 end
 
-function find_eq(v::T, b::Vector{T}) where T
+function find_eq(v::T, b::AbstractVector{T}) where T
     for vs in b
         if v == vs
             return true
@@ -1528,7 +1528,7 @@ function find_eq(v::T, b::Vector{T}) where T
     return false
 end
 
-function is_subset(a::Vector{T}, b::Vector{T}) where T
+function is_subset(a::AbstractVector{T}, b::AbstractVector{T}) where T
     for i in 1:length(a)
         v = a[i]
         if v == convert(T, INVALID_ID)
@@ -1541,7 +1541,7 @@ function is_subset(a::Vector{T}, b::Vector{T}) where T
     return true
 end
 
-function same_valid_ids(a::Vector{T}, b::Vector{T}) where T
+function same_valid_ids(a::AbstractVector{T}, b::AbstractVector{T}) where T
     if !is_subset(a, b)
         return false
     end
@@ -1898,7 +1898,7 @@ function generate_face_boundary(
                 dfaces = vertex_to_dfaces[vertex]
                 for dface1 in dfaces
                     vertices1 = dface_to_vertices[dface1]
-                    if same_valid_ids(collect(vertices),collect(vertices1))
+                    if same_valid_ids(vertices,vertices1)
                         dface2 = dface1
                         break
                     end
@@ -1933,7 +1933,7 @@ function generate_face_boundary(
                     ldface2 = Int32(INVALID_ID)
                     for (ldface1,lvertices1) in enumerate(ldface1_to_lvertices1)
                         vertices1 = view(lvertex1_to_vertex1,lvertices1)
-                        if same_valid_ids(collect(vertices),collect(vertices1))
+                        if same_valid_ids(vertices,vertices1)
                             ldface2 = ldface1
                             break
                         end

--- a/test/interpolation_tests.jl
+++ b/test/interpolation_tests.jl
@@ -105,6 +105,8 @@ D = GT.num_dims(mesh)
 
 V = GT.iso_parametric_space(Ωref;dirichlet_boundary=Γdiri)
 
+@test V.cache.face_dofs == GT.face_dofs(V)
+
 v = GT.zero_field(Float64,V)
 v2 = GT.zero_field(Float64,V)
 
@@ -134,10 +136,12 @@ GT.interpolate_dirichlet!(uref,y,1)
 
 order = 3
 V = GT.lagrange_space(Ωref,order)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
 
 V = GT.lagrange_space(Ωref,order;dirichlet_boundary=Γdiri)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
 
 w = GT.zero_field(Float64,V)
 w2 = GT.zero_field(Float64,V)
@@ -176,7 +180,8 @@ GT.interpolate_dirichlet!(uref,uh)
 #@test el2 < tol
 
 V = GT.lagrange_space(Γdiri,order)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
 
 Γ1 = GT.boundary(mesh;physical_names=["1-face-1"])
 Γ2 = GT.boundary(mesh;physical_names=["1-face-3"])
@@ -193,7 +198,7 @@ udiri = GT.piecewiese_field(u1,u2,u3)
 order = 1
 V = GT.lagrange_space(Ωref,order;dirichlet_boundary=Γdiri)
 
-GT.face_dofs(V)
+@test V.cache.face_dofs == GT.face_dofs(V)
 
 V |> GT.dirichlet_dof_location
 
@@ -202,9 +207,12 @@ GT.interpolate_dirichlet!(udiri,uh2)
 
 order = 1
 V = GT.lagrange_space(Ωref,order;dirichlet_boundary=Γdiri,conformity=:L2)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
+
 V = GT.lagrange_space(Ωref,order-1;dirichlet_boundary=Γdiri,conformity=:L2)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
 
 outdir = mkpath(joinpath(@__DIR__,"..","output"))
 vtk_grid(joinpath(outdir,"omega_ref"),Ωref;plot_params=(;refinement=40)) do plt
@@ -221,16 +229,21 @@ end
 Γ = GT.boundary(mesh;physical_names=["boundary_faces"])
 
 V = GT.lagrange_space(Γ,order;conformity=:L2)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
+
 V = GT.lagrange_space(Γ,order-1;conformity=:L2)
 GT.reference_fes(V) # TODO why 2 reference fes?
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
 
 
 order = 3
 m = GT.analytical_field(x->SVector(false,true),Γ)
 V = GT.lagrange_space(Ω,order;shape=(2,),dirichlet_boundary=m)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
+
 uh = GT.rand_field(Float64,V)
 
 vtk_grid(joinpath(outdir,"Vvec"),Ω;plot_params=(;refinement=10)) do plt
@@ -247,7 +260,9 @@ m1 = GT.analytical_field(x->SVector(false,true),Γ1)
 m2 = GT.analytical_field(x->SVector(true,false),Γ2)
 m = GT.piecewiese_field(m1,m2)
 V = GT.lagrange_space(Ω,order;shape=(2,),dirichlet_boundary=m)
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
+
 uh = GT.rand_field(Float64,V)
 vtk_grid(joinpath(outdir,"Vvec2"),Ω;plot_params=(;refinement=10)) do plt
     GT.plot!(plt,uh;label="uh")
@@ -257,7 +272,9 @@ end
 
 order = 0
 V = GT.lagrange_space(Ω,order,space=:P,dirichlet_boundary=GT.last_dof())
-GT.face_dofs(V)
+
+@test V.cache.face_dofs == GT.face_dofs(V)
+
 uh = GT.rand_field(Float64,V)
 
 vtk_grid(joinpath(outdir,"Vpdisc"),Ω;plot_params=(;refinement=10)) do plt


### PR DESCRIPTION
This PR attempts to make some fixes to improve performance of the hand written implementation of the Poisson problem based on profiling.

Changes made:
- [x] Add comments to hand written Poisson example.
- [x] Fix in some type-instabilities associated with `node_coordinates_from_monomials_exponents` and ` monomial_exponents_from_filter` (mesh.jl)
- [x] Add caches to sub-types of `AbstractSpace`: `IsoParametricSpace` and `LagrangeSpace`
- [x] Refactor `same_valid_ids` from mesh.jl