### PR TITLE
Make sure the CI is triggered also on closing of the PR (for merge)

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -5,6 +5,12 @@ on:
       - main
     tags: '*'
   pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - synchronize
+      - closed
 
 concurrency:
   # Skip intermediate builds: always.


### PR DESCRIPTION
The fix for #151 still doesn't trigger on PR merge. This adds `closed` as a type to try to trigger the performance runs on merge to main.