### PR TITLE
New accessors / iterators

### DIFF
--- a/GalerkinToolkitExamples/src/poisson.jl
+++ b/GalerkinToolkitExamples/src/poisson.jl
@@ -245,15 +245,12 @@ end
 
 function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
 
+    ∇ = ForwardDiff.gradient
+
     #Accessors to the quantities on the
     #integration points
-    Ω = GT.domain(dΩ)
-    face_point_J = GT.jacobian_accessor(dΩ)
-    face_point_dV = GT.weight_accessor(dΩ)
-    face_npoints = GT.num_points_accessor(dΩ)
-    face_dofs = GT.dofs_accessor(V,Ω)
-    ∇ = ForwardDiff.gradient
-    face_point_dof_∇s = GT.shape_function_accessor(∇,V,dΩ)
+    V_dΩ_0 = GT.space_accessor(V,dΩ)
+    V_dΩ = GT.tabulate(∇,V_dΩ_0)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -261,31 +258,26 @@ function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
     Auu = zeros(T,n,n)
 
     #Numerical integration loop
-    for face in 1:GT.num_faces(Ω)
+    for V_face in GT.foreach_face(V_dΩ)
 
         #Get quantities at current face
-        npoints = face_npoints(face)
-        point_J = face_point_J(face)
-        point_dV = face_point_dV(face)
-        point_dof_∇s = face_point_dof_∇s(face)
-        dofs = face_dofs(face)
+        dofs = GT.dofs(V_face)
 
         #Reset face matrix
         fill!(Auu,zero(T))
 
         #Loop over integration points
-        for point in 1:npoints
+        for V_point in GT.foreach_point(V_face)
 
             #Get quantities at current integration point
-            J = point_J(point)
-            dV = point_dV(point,J)
-            dof_∇s = point_dof_∇s(point,J)
+            dV = GT.weight(V_point)
+            dof_∇s = GT.shape_functions(∇,V_point)
 
             #Fill in face matrix
             for (i,dofi) in enumerate(dofs)
-                ∇v = dof_∇s(i)
+                ∇v = dof_∇s[i]
                 for (j,dofj) in enumerate(dofs)
-                    ∇u = dof_∇s(j)
+                    ∇u = dof_∇s[j]
                     Auu[i,j] += ∇v⋅∇u*dV
                 end
             end
@@ -304,37 +296,26 @@ end
 
 function integrate_error(g,uh,dΩ)
 
+    ∇ = ForwardDiff.gradient
+
     #Accessors to the quantities on the
     #integration points
-    face_point_x = GT.coordinate_accessor(dΩ)
-    face_point_J = GT.jacobian_accessor(dΩ)
-    face_point_dV = GT.weight_accessor(dΩ)
-    face_npoints = GT.num_points_accessor(dΩ)
-    face_point_uhx = GT.discrete_field_accessor(GT.value,uh,dΩ)
-    face_point_∇uhx = GT.discrete_field_accessor(ForwardDiff.gradient,uh,dΩ)
+    uh_dΩ_1 = GT.field_accessor(uh,dΩ)
+    uh_dΩ_2 = GT.tabulate(∇,uh_dΩ_1)
+    uh_dΩ_3 = GT.tabulate(GT.value,uh_dΩ_2)
+    uh_dΩ = GT.compute(GT.coordinate,uh_dΩ_3)
 
     #Numerical integration loop
     s = 0.0
     s1 = 0.0
-    Ω = GT.domain(dΩ)
-    for face in 1:GT.num_faces(Ω)
-
-        #Get quantities at current face
-        npoints = face_npoints(face)
-        point_x = face_point_x(face)
-        point_J = face_point_J(face)
-        point_dV = face_point_dV(face)
-        point_uhx = face_point_uhx(face)
-        point_∇uhx = face_point_∇uhx(face)
-
-        for point in 1:npoints
+    for uh_face in GT.foreach_face(uh_dΩ)
+        for uh_point in GT.foreach_point(uh_face)
 
             #Get quantities at current integration point
-            x = point_x(point)
-            J = point_J(point)
-            dV = point_dV(point,J)
-            uhx = point_uhx(point,J)
-            ∇uhx = point_∇uhx(point,J)
+            x = GT.coordinate(uh_point)
+            dV = GT.weight(uh_point)
+            uhx = GT.field(GT.value,uh_point)
+            ∇uhx = GT.field(∇,uh_point)
 
             #Add contribution
             s += abs2(uhx-g.definition(x))*dV

--- a/GalerkinToolkitExamples/src/poisson.jl
+++ b/GalerkinToolkitExamples/src/poisson.jl
@@ -249,8 +249,8 @@ function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
 
     #Accessors to the quantities on the
     #integration points
-    V_dΩ_0 = GT.space_accessor(V,dΩ)
-    V_dΩ = GT.tabulate(∇,V_dΩ_0)
+    V_faces_0 = GT.foreach_face(V,dΩ)
+    V_faces = GT.tabulate(∇,V_faces_0)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -258,7 +258,7 @@ function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
     Auu = zeros(T,n,n)
 
     #Numerical integration loop
-    for V_face in GT.foreach_face(V_dΩ)
+    for V_face in V_faces
 
         #Get quantities at current face
         dofs = GT.dofs(V_face)
@@ -300,15 +300,15 @@ function integrate_error(g,uh,dΩ)
 
     #Accessors to the quantities on the
     #integration points
-    uh_dΩ_1 = GT.field_accessor(uh,dΩ)
-    uh_dΩ_2 = GT.tabulate(∇,uh_dΩ_1)
-    uh_dΩ_3 = GT.tabulate(GT.value,uh_dΩ_2)
-    uh_dΩ = GT.compute(GT.coordinate,uh_dΩ_3)
+    uh_faces_1 = GT.foreach_face(uh,dΩ)
+    uh_faces_2 = GT.tabulate(∇,uh_faces_1)
+    uh_faces_3 = GT.tabulate(GT.value,uh_faces_2)
+    uh_faces = GT.compute(GT.coordinate,uh_faces_3)
 
     #Numerical integration loop
     s = 0.0
     s1 = 0.0
-    for uh_face in GT.foreach_face(uh_dΩ)
+    for uh_face in uh_faces
         for uh_point in GT.foreach_point(uh_face)
 
             #Get quantities at current integration point

--- a/docs/src/src_jl/example_hello_world.jl
+++ b/docs/src/src_jl/example_hello_world.jl
@@ -95,8 +95,8 @@ function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
 
     #Accessors to the quantities on the
     #integration points
-    V_dΩ_0 = GT.space_accessor(V,dΩ)
-    V_dΩ = GT.tabulate(∇,V_dΩ_0)
+    V_faces_0 = GT.foreach_face(V,dΩ)
+    V_faces = GT.tabulate(∇,V_faces_0)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -104,7 +104,7 @@ function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
     Auu = zeros(T,n,n)
 
     #Numerical integration loop
-    for V_face in GT.foreach_face(V_dΩ)
+    for V_face in V_faces
 
         #Get quantities at current face
         dofs = GT.dofs(V_face)
@@ -142,13 +142,13 @@ function integrate_l2_error(g,uh,dΩ)
 
     #Accessors to the quantities on the
     #integration points
-    uh_dΩ_1 = GT.field_accessor(uh,dΩ)
-    uh_dΩ_2 = GT.tabulate(GT.value,uh_dΩ_1)
-    uh_dΩ = GT.compute(GT.coordinate,uh_dΩ_2)
+    uh_faces_1 = GT.foreach_face(uh,dΩ)
+    uh_faces_2 = GT.tabulate(GT.value,uh_faces_1)
+    uh_faces = GT.compute(GT.coordinate,uh_faces_2)
 
     #Numerical integration loop
     s = 0.0
-    for uh_face in GT.foreach_face(uh_dΩ)
+    for uh_face in uh_faces
         for uh_point in GT.foreach_point(uh_face)
 
             #Get quantities at current integration point

--- a/docs/src/src_jl/example_hello_world.jl
+++ b/docs/src/src_jl/example_hello_world.jl
@@ -93,7 +93,7 @@ function assemble_matrix!(A_alloc,Ad_alloc,V,dΩ)
 
     ∇ = ForwardDiff.gradient
 
-    #Accessors to the quantities on the
+    #Iterators to the quantities on the
     #integration points
     V_faces_0 = GT.foreach_face(V,dΩ)
     V_faces = GT.tabulate(∇,V_faces_0)
@@ -140,7 +140,7 @@ end
 #Always use a function, never the global scope
 function integrate_l2_error(g,uh,dΩ)
 
-    #Accessors to the quantities on the
+    #Iterators to the quantities on the
     #integration points
     uh_faces_1 = GT.foreach_face(uh,dΩ)
     uh_faces_2 = GT.tabulate(GT.value,uh_faces_1)

--- a/docs/src/src_jl/example_poisson_equation.jl
+++ b/docs/src/src_jl/example_poisson_equation.jl
@@ -106,10 +106,10 @@ function assemble_in_Ω!(A_alloc,Ad_alloc,b_alloc,V,f,dΩ)
 
     #Accessors to the quantities on the
     #integration points
-    V_dΩ_1 = GT.space_accessor(V,dΩ)
-    V_dΩ_2 = GT.tabulate(∇,V_dΩ_1)
-    V_dΩ_3 = GT.tabulate(GT.value,V_dΩ_2)
-    V_dΩ = GT.compute(GT.coordinate,V_dΩ_3)
+    V_faces_1 = GT.foreach_face(V,dΩ)
+    V_faces_2 = GT.tabulate(∇,V_faces_1)
+    V_faces_3 = GT.tabulate(GT.value,V_faces_2)
+    V_faces = GT.compute(GT.coordinate,V_faces_3)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -118,7 +118,7 @@ function assemble_in_Ω!(A_alloc,Ad_alloc,b_alloc,V,f,dΩ)
     bu = zeros(T,n)
 
     #Numerical integration loop
-    for V_face in GT.foreach_face(V_dΩ)
+    for V_face in V_faces
 
         #Get quantities at current face
         dofs = GT.dofs(V_face)
@@ -162,9 +162,9 @@ function assemble_in_Γn!(b_alloc,V,h,dΓn)
 
     #Accessors to the quantities on the
     #integration points
-    V_dΓn_1 = GT.space_accessor(V,dΓn)
-    V_dΓn_2 = GT.tabulate(GT.value,V_dΓn_1)
-    V_dΓn = GT.compute(GT.coordinate,V_dΓn_2)
+    V_faces_1 = GT.foreach_face(V,dΓn)
+    V_faces_2 = GT.tabulate(GT.value,V_faces_1)
+    V_faces = GT.compute(GT.coordinate,V_faces_2)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -173,7 +173,7 @@ function assemble_in_Γn!(b_alloc,V,h,dΓn)
     bu = zeros(T,n)
 
     #Numerical integration loop
-    for V_face in GT.foreach_face(V_dΓn)
+    for V_face in V_faces
 
         #Get quantities at current face
         dofs = GT.dofs(V_face)

--- a/docs/src/src_jl/example_poisson_equation.jl
+++ b/docs/src/src_jl/example_poisson_equation.jl
@@ -106,15 +106,10 @@ function assemble_in_Ω!(A_alloc,Ad_alloc,b_alloc,V,f,dΩ)
 
     #Accessors to the quantities on the
     #integration points
-    Ω = GT.domain(dΩ)
-    face_point_x = GT.coordinate_accessor(dΩ)
-    face_point_J = GT.jacobian_accessor(dΩ)
-    face_point_dV = GT.weight_accessor(dΩ)
-    face_npoints = GT.num_points_accessor(dΩ)
-    face_dofs = GT.dofs_accessor(V,Ω)
-    face_point_dof_s = GT.shape_function_accessor(GT.value,V,dΩ)
-    ∇ = ForwardDiff.gradient
-    face_point_dof_∇s = GT.shape_function_accessor(∇,V,dΩ)
+    V_dΩ_1 = GT.space_accessor(V,dΩ)
+    V_dΩ_2 = GT.tabulate(∇,V_dΩ_1)
+    V_dΩ_3 = GT.tabulate(GT.value,V_dΩ_2)
+    V_dΩ = GT.compute(GT.coordinate,V_dΩ_3)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -123,38 +118,31 @@ function assemble_in_Ω!(A_alloc,Ad_alloc,b_alloc,V,f,dΩ)
     bu = zeros(T,n)
 
     #Numerical integration loop
-    for face in 1:GT.num_faces(Ω)
+    for V_face in GT.foreach_face(V_dΩ)
 
         #Get quantities at current face
-        npoints = face_npoints(face)
-        point_x = face_point_x(face)
-        point_J = face_point_J(face)
-        point_dV = face_point_dV(face)
-        point_dof_s = face_point_dof_s(face)
-        point_dof_∇s = face_point_dof_∇s(face)
-        dofs = face_dofs(face)
+        dofs = GT.dofs(V_face)
 
         #Reset face matrix
         fill!(Auu,zero(T))
         fill!(bu,zero(T))
 
         #Loop over integration points
-        for point in 1:npoints
+        for V_point in GT.foreach_point(V_face)
 
             #Get quantities at current integration point
-            x = point_x(point)
-            J = point_J(point)
-            dV = point_dV(point,J)
-            dof_s = point_dof_s(point)
-            dof_∇s = point_dof_∇s(point,J)
+            x = GT.coordinate(V_point)
+            dV = GT.weight(V_point)
+            dof_s = GT.shape_functions(GT.value,V_point)
+            dof_∇s = GT.shape_functions(∇,V_point)
 
             #Fill in face matrix and vector
             for (i,dofi) in enumerate(dofs)
-                v = dof_s(i)
-                ∇v = dof_∇s(i)
+                v = dof_s[i]
+                ∇v = dof_∇s[i]
                 bu[i] += f.definition(x)*v*dV
                 for (j,dofj) in enumerate(dofs)
-                    ∇u = dof_∇s(j)
+                    ∇u = dof_∇s[j]
                     Auu[i,j] += ∇v⋅∇u*dV
                 end
             end
@@ -174,12 +162,9 @@ function assemble_in_Γn!(b_alloc,V,h,dΓn)
 
     #Accessors to the quantities on the
     #integration points
-    Γn = GT.domain(dΓn)
-    face_point_x = GT.coordinate_accessor(dΓn)
-    face_point_dV = GT.weight_accessor(dΓn)
-    face_npoints = GT.num_points_accessor(dΓn)
-    face_dofs = GT.dofs_accessor(V,Γn)
-    face_point_dof_s = GT.shape_function_accessor(GT.value,V,dΓn)
+    V_dΓn_1 = GT.space_accessor(V,dΓn)
+    V_dΓn_2 = GT.tabulate(GT.value,V_dΓn_1)
+    V_dΓn = GT.compute(GT.coordinate,V_dΓn_2)
 
     #Temporaries
     n = GT.max_num_reference_dofs(V)
@@ -188,29 +173,25 @@ function assemble_in_Γn!(b_alloc,V,h,dΓn)
     bu = zeros(T,n)
 
     #Numerical integration loop
-    for face in 1:GT.num_faces(Γn)
+    for V_face in GT.foreach_face(V_dΓn)
 
         #Get quantities at current face
-        npoints = face_npoints(face)
-        point_x = face_point_x(face)
-        point_dV = face_point_dV(face)
-        point_dof_s = face_point_dof_s(face)
-        dofs = face_dofs(face)
+        dofs = GT.dofs(V_face)
 
         #Reset face vector
         fill!(bu,zero(T))
 
         #Loop over integration points
-        for point in 1:npoints
+        for V_point in GT.foreach_point(V_face)
 
             #Get quantities at current integration point
-            x = point_x(point)
-            dV = point_dV(point)
-            dof_s = point_dof_s(point)
+            x = GT.coordinate(V_point)
+            dV = GT.weight(V_point)
+            dof_s = GT.shape_functions(GT.value,V_point)
 
             #Fill in face matrix and vector
             for (i,dofi) in enumerate(dofs)
-                v = dof_s(i)
+                v = dof_s[i]
                 bu[i] += h.definition(x)*v*dV
             end
         end

--- a/docs/src/src_jl/example_poisson_equation.jl
+++ b/docs/src/src_jl/example_poisson_equation.jl
@@ -104,7 +104,7 @@ nothing # hide
 #Always use a function, never the global scope
 function assemble_in_Ω!(A_alloc,Ad_alloc,b_alloc,V,f,dΩ)
 
-    #Accessors to the quantities on the
+    #Iterators to the quantities on the
     #integration points
     V_faces_1 = GT.foreach_face(V,dΩ)
     V_faces_2 = GT.tabulate(∇,V_faces_1)
@@ -160,7 +160,7 @@ end
 #Always use a function, never the global scope
 function assemble_in_Γn!(b_alloc,V,h,dΓn)
 
-    #Accessors to the quantities on the
+    #Iterators to the quantities on the
     #integration points
     V_faces_1 = GT.foreach_face(V,dΓn)
     V_faces_2 = GT.tabulate(GT.value,V_faces_1)

--- a/docs/src/src_jl/manual_meshes.jl
+++ b/docs/src/src_jl/manual_meshes.jl
@@ -252,16 +252,9 @@ y = StaticArrays.SVector(0.5,)
 
 # The returned value should be the mid point of the edge number 2.
 
-# ### Iterators
-#
 # Geting information from a mesh might be tedious for the many array indirection present.
 # To fix this, the library provides iterators to visit the faces of the mesh.
-# These functions are fully explained in Section Iterators. Here, we provide an example of they in action.
-#
-# ### Example
-#
-# We rewrite the previous example using an iterator object.
-
+# These functions are fully explained in Section Iterators. We rewrite this example using an iterator object.
 
 #Face iterator
 d = 1

--- a/docs/src/src_jl/manual_meshes.jl
+++ b/docs/src/src_jl/manual_meshes.jl
@@ -255,7 +255,7 @@ y = StaticArrays.SVector(0.5,)
 # ### Iterators
 #
 # Geting information from a mesh might be tedious for the many array indirection present.
-# To fix this, the library provides accessors objects to visit the faces of the mesh.
+# To fix this, the library provides iterators to visit the faces of the mesh.
 # These functions are fully explained in Section Iterators. Here, we provide an example of they in action.
 #
 # ### Example
@@ -263,11 +263,11 @@ y = StaticArrays.SVector(0.5,)
 # We rewrite the previous example using an iterator object.
 
 
-# Face iterator
+#Face iterator
 d = 1
 mesh_faces = GT.foreach_face(mesh,d)
 
-# Restrict iterator at current face
+#Restrict iterator at current face
 face = 2
 mesh_face = mesh_faces[face]
 lnode_s = GT.shape_functions(mesh_face)

--- a/src/abstract_types.jl
+++ b/src/abstract_types.jl
@@ -1,3 +1,5 @@
+abstract type NewAbstractAccessor <: AbstractType end
+
 abstract type AbstractAccessor <: Function end
 
 function Base.show(io::IO,data::GT.AbstractAccessor)

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -3,8 +3,9 @@ function foreach_face(a)
     ForeachFace(a)
 end
 
-function foreach_face(mesh::AbstractMesh)
-    mesh_acc = mesh_accessor(mesh)
+function foreach_face(mesh::AbstractMesh,D=Val(num_dims(mesh)))
+    domain = GT.domain(mesh,D)
+    mesh_acc = mesh_accessor(mesh,domain,Val(val_parameter(D)))
     foreach_face(mesh_acc)
 end
 
@@ -30,6 +31,7 @@ end
 Base.length(iter::ForeachFace) = num_faces(iter.accessor)
 Base.isdone(iter::ForeachFace,face) = face > length(iter)
 Base.getindex(iter::ForeachFace,face) = at_face(iter.accessor,face)
+Base.keys(iter::ForeachFace) = LinearIndices((length(iter),))
 
 function Base.iterate(iter::ForeachFace,face=1)
     if Base.isdone(iter,face)
@@ -51,6 +53,7 @@ end
 Base.length(iter::ForeachFaceAround) = num_faces_around(iter.accessor)
 Base.isdone(iter::ForeachFaceAround,face_around) = face_around > length(iter)
 Base.getindex(iter::ForeachFaceAround,face_around) = at_face_around(iter.accessor,face_around)
+Base.keys(iter::ForeachFaceAround) = LinearIndices((length(iter),))
 
 function Base.iterate(iter::ForeachFaceAround,face_around=1)
     if Base.isdone(iter,face_around)
@@ -72,6 +75,7 @@ end
 Base.length(iter::ForeachPoint) = num_points(iter.accessor)
 Base.isdone(iter::ForeachPoint,point) = point > length(iter)
 Base.getindex(iter::ForeachPoint,point) = at_point(iter.accessor,point)
+Base.keys(iter::ForeachPoint) = LinearIndices((length(iter),))
 
 function Base.iterate(iter::ForeachPoint,point=1)
     if Base.isdone(iter,point)
@@ -286,8 +290,8 @@ function shape_functions(a::ReferenceSpaceAccessor)
     (;Dface,space) = a.contents
     Dface_Drid = face_reference_id(space)
     Drid = Dface_Drid[Dface]
-    Drid_rspace = reference_spaces(mesh,D)
-    rspace = Drid_space[Drid]
+    Drid_rspace = reference_spaces(space)
+    rspace = Drid_rspace[Drid]
     shape_functions(rspace)
 end
 

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -662,7 +662,7 @@ end
 
 function shape_functions(f,a::SpaceAccessor{AtSkeleton})
     (;space,mesh_accessor,reference_space_accessor) = a.contents
-    face_around = mesh_accessor.contents.space_accessor.face_around
+    face_around = mesh_accessor.contents.space_accessor.contents.face_around
     dof_sref = GT.shape_functions(f,reference_space_accessor)
     dof_sphys = workspace(f,a)[face_around]
     ndofs = length(dof_sref)

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -3,6 +3,16 @@ function foreach_face(a)
     ForeachFace(a)
 end
 
+function foreach_face(mesh::AbstractMesh,args...)
+    mesh_acc = mesh_accessor(mesh,args...)
+    foreach_face(mesh_acc)
+end
+
+function foreach_face(quadrature::AbstractQuadrature)
+    acc = quadrature_accessor(quadrature)
+    foreach_face(acc)
+end
+
 struct ForeachFace{A} <: AbstractType
     accessor::A
 end
@@ -65,11 +75,6 @@ function Base.iterate(iter::ForeachPoint,point=1)
         accessor = iter[point]
         (accessor,point+1)
     end
-end
-
-function foreach_face(mesh::AbstractMesh,args...)
-    mesh_acc = mesh_accessor(mesh,args...)
-    foreach_face(mesh_acc)
 end
 
 function mesh_accessor(mesh::AbstractMesh)
@@ -344,7 +349,15 @@ function map_unit_normal(J,n)
     end
 end
 
-
+function quadrature_accessor(quadrature::AbstractQuadrature)
+    domain = GT.domain(quadrature)
+    mesh = GT.mesh(domain)
+    d = Val(num_dims(domain))
+    acc1 = mesh_accessor(mesh,quadrature,d)
+    acc2 = compute(GT.value,acc1)
+    acc3 = compute(ForwardDiff.gradient,acc2)
+    acc3
+end
 
 
 

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -612,13 +612,13 @@ end
 
 node_coordinates(m::Mesh) = m.contents.node_coordinates
 face_nodes(m::Mesh) = m.contents.face_nodes
-face_nodes(m::Mesh,d) = m.contents.face_nodes[d+1]
+face_nodes(m::Mesh,d) = m.contents.face_nodes[val_parameter(d)+1]
 face_reference_id(m::Mesh) = m.contents.face_reference_id
-face_reference_id(m::Mesh,d) = m.contents.face_reference_id[d+1]
+face_reference_id(m::Mesh,d) = m.contents.face_reference_id[val_parameter(d)+1]
 reference_spaces(m::Mesh) = m.contents.reference_spaces
 reference_spaces(m::Mesh,d) = m.contents.reference_spaces[val_parameter(d)+1]
 group_faces(m::Mesh) = m.contents.group_faces
-group_faces(m::Mesh,d) = m.contents.group_faces[d+1]
+group_faces(m::Mesh,d) = m.contents.group_faces[val_parameter(d)+1]
 periodic_nodes(m::Mesh) = m.contents.periodic_nodes
 is_cell_complex(m::Mesh) = val_parameter(m.contents.is_cell_complex)
 workspace(m::Mesh) = m.contents.workspace

--- a/src/mesh.jl
+++ b/src/mesh.jl
@@ -838,7 +838,7 @@ num_dirichlet_dofs(space::MeshSpace) = 0
 
 function face_dofs(space::MeshSpace)
     D = num_dims(space)
-    face_dofs(space.mesh,D)
+    face_nodes(space.mesh,D)
 end
 
 

--- a/src/quadrature.jl
+++ b/src/quadrature.jl
@@ -18,6 +18,10 @@ function face_quadrature(;domain,coordinates,weights)
     FaceQuadrature(contents)
 end
 
+function num_points(q::AbstractQuadrature)
+    length(weights(q))
+end
+
 struct FaceQuadrature{A} <: AbstractFaceQuadrature
     contents::A
 end

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -96,7 +96,27 @@ for mesh_dface in mesh_iter
     end
 end
 
-xxx
+dΩ_iter = GT.foreach_face(dΩ)
+dΩ_face = dΩ_iter[2]
+dΩ_iter = GT.foreach_point(dΩ_face)
+dΩ_point = dΩ_iter[2]
+@show GT.coordinate(dΩ_point)
+@show GT.weight(dΩ_point)
+
+dΓ_iter = GT.foreach_face(dΓ)
+dΓ_face = dΓ_iter[2]
+dΓ_iter = GT.foreach_point(dΓ_face)
+dΓ_point = dΓ_iter[2]
+@show GT.coordinate(dΓ_point)
+@show GT.weight(dΓ_point)
+
+dΛ_iter = GT.foreach_face(dΛ)
+dΛ_face = dΛ_iter[2]
+dΛ_iter = GT.foreach_point(dΛ_face)
+dΛ_point = dΛ_iter[2]
+@show GT.coordinate(dΛ_point)
+@show GT.weight(dΛ_point)
+
 
 f_l_x = GT.node_coordinate_accessor(mesh,2)
 @show f_l_x(2)(1)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -21,7 +21,8 @@ dΩ = GT.measure(Ω,2*k)
 dΓ = GT.measure(Γ,2*k)
 dΛ = GT.measure(Λ,2*k)
 
-mesh_dΩ = GT.mesh_accessor(mesh,dΩ)
+D = GT.num_dims(mesh)
+mesh_dΩ = GT.mesh_accessor(mesh,D,dΩ)
 mesh_dΩ = GT.tabulate(GT.value,mesh_dΩ)
 mesh_dΩ = GT.tabulate(ForwardDiff.gradient,mesh_dΩ)
 mesh_faces = GT.foreach_face(mesh_dΩ)
@@ -46,7 +47,7 @@ for mesh_face in GT.foreach_face(mesh_dΩ)
     end
 end
 
-mesh_dΓ = GT.mesh_accessor(mesh,dΓ)
+mesh_dΓ = GT.mesh_accessor(mesh,D,dΓ)
 mesh_dΓ = GT.tabulate(GT.value,mesh_dΓ)
 mesh_dΓ = GT.tabulate(ForwardDiff.gradient,mesh_dΓ)
 mesh_faces = GT.foreach_face(mesh_dΓ)
@@ -71,7 +72,7 @@ for mesh_face in GT.foreach_face(mesh_dΓ)
     end
 end
 
-mesh_dΛ = GT.mesh_accessor(mesh,dΛ)
+mesh_dΛ = GT.mesh_accessor(mesh,D,dΛ)
 mesh_dΛ = GT.tabulate(GT.value,mesh_dΛ)
 mesh_dΛ = GT.tabulate(ForwardDiff.gradient,mesh_dΛ)
 mesh_dΛ = GT.compute(GT.unit_normal,mesh_dΛ)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -125,16 +125,22 @@ dΛ_point = dΛ_points[2]
 @show GT.weight(dΛ_point)
 
 V_dΩ = GT.space_accessor(V,dΩ)
-V_Ω = GT.compute(GT.value,V_dΩ)
-V_Ω = GT.compute(ForwardDiff.gradient,V_dΩ)
+V_dΩ = GT.compute(GT.value,V_dΩ)
+V_dΩ = GT.compute(ForwardDiff.gradient,V_dΩ)
 V_faces = GT.foreach_face(V_dΩ)
 V_face = V_faces[1]
 V_points = GT.foreach_point(V_face)
 V_point = V_points[1]
 @show GT.shape_functions(GT.value,V_point)
 
-xxx
-
+uh = GT.zero_field(Float64,V)
+uh_dΩ = GT.field_accessor(uh,dΩ)
+uh_dΩ = GT.compute(GT.value,uh_dΩ)
+uh_faces = GT.foreach_face(uh_dΩ)
+uh_face = uh_faces[1]
+uh_points = GT.foreach_point(uh_face)
+uh_point = uh_points[1]
+@show GT.field(GT.value,uh_point)
 
 f_l_x = GT.node_coordinate_accessor(mesh,2)
 @show f_l_x(2)(1)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -21,18 +21,20 @@ dΩ = GT.measure(Ω,2*k)
 dΓ = GT.measure(Γ,2*k)
 dΛ = GT.measure(Λ,2*k)
 
-mesh_iter = GT.foreach_face(mesh)
-mesh_iter = GT.compute(GT.value,mesh_iter)
-mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
-mesh_face = mesh_iter[2]
+mesh_dΩ = GT.mesh_accessor(mesh,dΩ)
+mesh_dΩ = GT.compute(GT.value,mesh_dΩ)
+mesh_dΩ = GT.compute(ForwardDiff.gradient,mesh_dΩ)
+mesh_faces = GT.foreach_face(mesh_dΩ)
+mesh_face = mesh_faces[2]
 @show GT.nodes(mesh_face)
 @show GT.node_coordinates(mesh_face)
-mesh_point = GT.at_point(mesh_face,1)
+mesh_points = GT.foreach_point(mesh_face)
+mesh_point = mesh_points[1]
 @show GT.coordinate(GT.value,mesh_point)
 @show GT.coordinate(ForwardDiff.jacobian,mesh_point)
 @show GT.weight(mesh_point)
 
-for mesh_face in mesh_iter
+for mesh_face in GT.foreach_face(mesh_dΩ)
     GT.nodes(mesh_face)
     GT.node_coordinates(mesh_face)
     GT.num_nodes(mesh_face)
@@ -44,18 +46,20 @@ for mesh_face in mesh_iter
     end
 end
 
-mesh_iter = GT.foreach_face(mesh,dΓ)
-mesh_iter = GT.compute(GT.value,mesh_iter)
-mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
+mesh_dΓ = GT.mesh_accessor(mesh,dΓ)
+mesh_dΓ = GT.compute(GT.value,mesh_dΓ)
+mesh_dΓ = GT.compute(ForwardDiff.gradient,mesh_dΓ)
+mesh_faces = GT.foreach_face(mesh_dΓ)
 mesh_face = mesh_iter[2]
 @show GT.nodes(mesh_face)
 @show GT.node_coordinates(mesh_face)
-mesh_point = GT.at_point(mesh_face,1)
+mesh_points = GT.foreach_point(mesh_face)
+mesh_point = mesh_points[1]
 @show GT.coordinate(GT.value,mesh_point)
 @show GT.coordinate(ForwardDiff.jacobian,mesh_point)
 @show GT.weight(mesh_point)
 
-for mesh_face in mesh_iter
+for mesh_face in GT.foreach_face(mesh_dΓ)
     GT.nodes(mesh_face)
     GT.node_coordinates(mesh_face)
     GT.num_nodes(mesh_face)
@@ -67,21 +71,24 @@ for mesh_face in mesh_iter
     end
 end
 
-mesh_iter = GT.foreach_face(mesh,dΛ)
-mesh_iter = GT.compute(GT.value,mesh_iter)
-mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
-mesh_iter = GT.compute(GT.unit_normal,mesh_iter)
-mesh_dface = mesh_iter[2]
-mesh_Dface = GT.at_face_around(mesh_dface,2)
+mesh_dΛ = GT.mesh_accessor(mesh,dΛ)
+mesh_dΛ = GT.compute(GT.value,mesh_dΛ)
+mesh_dΛ = GT.compute(ForwardDiff.gradient,mesh_dΛ)
+mesh_dΛ = GT.compute(GT.unit_normal,mesh_dΛ)
+mesh_dfaces = GT.foreach_face(mesh_dΛ)
+mesh_dface = mesh_dfaces[2]
+mesh_Dfaces = GT.foreach_face_around(mesh_dface)
+mesh_Dface = mesh_Dfaces[2]
 @show GT.nodes(mesh_Dface)
 @show GT.node_coordinates(mesh_Dface)
-mesh_point = GT.at_point(mesh_Dface,1)
+mesh_points = GT.foreach_point(mesh_Dface)
+mesh_point = mesh_point[1]
 @show GT.coordinate(GT.value,mesh_point)
 @show GT.coordinate(ForwardDiff.jacobian,mesh_point)
 @show GT.weight(mesh_point)
 @show GT.unit_normal(mesh_point)
 
-for mesh_dface in mesh_iter
+for mesh_dface in GT.foreach_face(mesh_dΛ)
     for mesh_Dface in GT.foreach_face_around(mesh_dface)
         GT.nodes(mesh_Dface)
         GT.node_coordinates(mesh_Dface)
@@ -96,26 +103,37 @@ for mesh_dface in mesh_iter
     end
 end
 
-dΩ_iter = GT.foreach_face(dΩ)
-dΩ_face = dΩ_iter[2]
-dΩ_iter = GT.foreach_point(dΩ_face)
-dΩ_point = dΩ_iter[2]
+dΩ_faces = GT.foreach_face(dΩ)
+dΩ_face = dΩ_faces[2]
+dΩ_points = GT.foreach_point(dΩ_face)
+dΩ_point = dΩ_points[2]
 @show GT.coordinate(dΩ_point)
 @show GT.weight(dΩ_point)
 
-dΓ_iter = GT.foreach_face(dΓ)
-dΓ_face = dΓ_iter[2]
-dΓ_iter = GT.foreach_point(dΓ_face)
+dΓ_faces = GT.foreach_face(dΓ)
+dΓ_face = dΓ_faces[2]
+dΓ_points = GT.foreach_point(dΓ_face)
 dΓ_point = dΓ_iter[2]
 @show GT.coordinate(dΓ_point)
 @show GT.weight(dΓ_point)
 
-dΛ_iter = GT.foreach_face(dΛ)
-dΛ_face = dΛ_iter[2]
-dΛ_iter = GT.foreach_point(dΛ_face)
-dΛ_point = dΛ_iter[2]
+dΛ_dfaces = GT.foreach_face(dΛ)
+dΛ_dface = dΛ_dfaces[2]
+dΛ_Dfaces = GT.foreach_face_around(dΛ_dface)
+dΛ_Dface = dΛ_Dfaces[2]
+dΛ_points = GT.foreach_point(dΛ_Dface)
+dΛ_point = dΛ_points[2]
 @show GT.coordinate(dΛ_point)
 @show GT.weight(dΛ_point)
+
+V_dΩ = GT.space_accessor(V,dΩ)
+V_Ω = GT.compute(GT.value,V_dΩ)
+V_Ω = GT.compute(ForwardDiff.gradient,V_dΩ)
+V_faces = GT.foreach_face(V_dΩ)
+V_face = V_faces[1]
+V_points = GT.foreach_point(V_face)
+V_point = V_points[1]
+@show GT.shape_functions(GT.value,V_point)
 
 
 f_l_x = GT.node_coordinate_accessor(mesh,2)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -22,8 +22,8 @@ dΓ = GT.measure(Γ,2*k)
 dΛ = GT.measure(Λ,2*k)
 
 mesh_dΩ = GT.mesh_accessor(mesh,dΩ)
-mesh_dΩ = GT.compute(GT.value,mesh_dΩ)
-mesh_dΩ = GT.compute(ForwardDiff.gradient,mesh_dΩ)
+mesh_dΩ = GT.tabulate(GT.value,mesh_dΩ)
+mesh_dΩ = GT.tabulate(ForwardDiff.gradient,mesh_dΩ)
 mesh_faces = GT.foreach_face(mesh_dΩ)
 mesh_face = mesh_faces[2]
 @show GT.nodes(mesh_face)
@@ -47,8 +47,8 @@ for mesh_face in GT.foreach_face(mesh_dΩ)
 end
 
 mesh_dΓ = GT.mesh_accessor(mesh,dΓ)
-mesh_dΓ = GT.compute(GT.value,mesh_dΓ)
-mesh_dΓ = GT.compute(ForwardDiff.gradient,mesh_dΓ)
+mesh_dΓ = GT.tabulate(GT.value,mesh_dΓ)
+mesh_dΓ = GT.tabulate(ForwardDiff.gradient,mesh_dΓ)
 mesh_faces = GT.foreach_face(mesh_dΓ)
 mesh_face = mesh_faces[2]
 @show GT.nodes(mesh_face)
@@ -72,8 +72,8 @@ for mesh_face in GT.foreach_face(mesh_dΓ)
 end
 
 mesh_dΛ = GT.mesh_accessor(mesh,dΛ)
-mesh_dΛ = GT.compute(GT.value,mesh_dΛ)
-mesh_dΛ = GT.compute(ForwardDiff.gradient,mesh_dΛ)
+mesh_dΛ = GT.tabulate(GT.value,mesh_dΛ)
+mesh_dΛ = GT.tabulate(ForwardDiff.gradient,mesh_dΛ)
 mesh_dΛ = GT.compute(GT.unit_normal,mesh_dΛ)
 mesh_dfaces = GT.foreach_face(mesh_dΛ)
 mesh_dface = mesh_dfaces[2]
@@ -125,8 +125,8 @@ dΛ_point = dΛ_points[2]
 @show GT.weight(dΛ_point)
 
 V_dΩ = GT.space_accessor(V,dΩ)
-V_dΩ = GT.compute(GT.value,V_dΩ)
-V_dΩ = GT.compute(ForwardDiff.gradient,V_dΩ)
+V_dΩ = GT.tabulate(GT.value,V_dΩ)
+V_dΩ = GT.tabulate(ForwardDiff.gradient,V_dΩ)
 V_faces = GT.foreach_face(V_dΩ)
 V_face = V_faces[1]
 V_points = GT.foreach_point(V_face)
@@ -135,7 +135,7 @@ V_point = V_points[1]
 
 uh = GT.zero_field(Float64,V)
 uh_dΩ = GT.field_accessor(uh,dΩ)
-uh_dΩ = GT.compute(GT.value,uh_dΩ)
+uh_dΩ = GT.tabulate(GT.value,uh_dΩ)
 uh_faces = GT.foreach_face(uh_dΩ)
 uh_face = uh_faces[1]
 uh_points = GT.foreach_point(uh_face)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -50,7 +50,7 @@ mesh_dΓ = GT.mesh_accessor(mesh,dΓ)
 mesh_dΓ = GT.compute(GT.value,mesh_dΓ)
 mesh_dΓ = GT.compute(ForwardDiff.gradient,mesh_dΓ)
 mesh_faces = GT.foreach_face(mesh_dΓ)
-mesh_face = mesh_iter[2]
+mesh_face = mesh_faces[2]
 @show GT.nodes(mesh_face)
 @show GT.node_coordinates(mesh_face)
 mesh_points = GT.foreach_point(mesh_face)
@@ -82,7 +82,7 @@ mesh_Dface = mesh_Dfaces[2]
 @show GT.nodes(mesh_Dface)
 @show GT.node_coordinates(mesh_Dface)
 mesh_points = GT.foreach_point(mesh_Dface)
-mesh_point = mesh_point[1]
+mesh_point = mesh_points[1]
 @show GT.coordinate(GT.value,mesh_point)
 @show GT.coordinate(ForwardDiff.jacobian,mesh_point)
 @show GT.weight(mesh_point)
@@ -113,15 +113,13 @@ dΩ_point = dΩ_points[2]
 dΓ_faces = GT.foreach_face(dΓ)
 dΓ_face = dΓ_faces[2]
 dΓ_points = GT.foreach_point(dΓ_face)
-dΓ_point = dΓ_iter[2]
+dΓ_point = dΓ_points[2]
 @show GT.coordinate(dΓ_point)
 @show GT.weight(dΓ_point)
 
 dΛ_dfaces = GT.foreach_face(dΛ)
 dΛ_dface = dΛ_dfaces[2]
-dΛ_Dfaces = GT.foreach_face_around(dΛ_dface)
-dΛ_Dface = dΛ_Dfaces[2]
-dΛ_points = GT.foreach_point(dΛ_Dface)
+dΛ_points = GT.foreach_point(dΛ_dface)
 dΛ_point = dΛ_points[2]
 @show GT.coordinate(dΛ_point)
 @show GT.weight(dΛ_point)
@@ -134,6 +132,8 @@ V_face = V_faces[1]
 V_points = GT.foreach_point(V_face)
 V_point = V_points[1]
 @show GT.shape_functions(GT.value,V_point)
+
+xxx
 
 
 f_l_x = GT.node_coordinate_accessor(mesh,2)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -21,6 +21,52 @@ dΩ = GT.measure(Ω,2*k)
 dΓ = GT.measure(Γ,2*k)
 dΛ = GT.measure(Λ,2*k)
 
+mesh_iter = GT.foreach_face(mesh)
+mesh_iter = GT.compute(GT.value,mesh_iter)
+mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
+mesh_face = mesh_iter[2]
+@show GT.nodes(mesh_face)
+@show GT.node_coordinates(mesh_face)
+mesh_point = GT.at_point(mesh_face,1)
+@show GT.coordinate(GT.value,mesh_point)
+@show GT.coordinate(ForwardDiff.jacobian,mesh_point)
+@show GT.weight(mesh_point)
+
+for mesh_face in mesh_iter
+    GT.nodes(mesh_face)
+    GT.node_coordinates(mesh_face)
+    GT.num_nodes(mesh_face)
+    for mesh_point in GT.foreach_point(mesh_face)
+        GT.coordinate(mesh_point)
+        GT.coordinate(GT.value,mesh_point)
+        GT.coordinate(ForwardDiff.jacobian,mesh_point)
+        GT.weight(mesh_point)
+    end
+end
+
+mesh_iter = GT.foreach_face(mesh,dΓ)
+mesh_iter = GT.compute(GT.value,mesh_iter)
+mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
+mesh_face = mesh_iter[2]
+@show GT.nodes(mesh_face)
+@show GT.node_coordinates(mesh_face)
+mesh_point = GT.at_point(mesh_face,1)
+@show GT.coordinate(GT.value,mesh_point)
+@show GT.coordinate(ForwardDiff.jacobian,mesh_point)
+@show GT.weight(mesh_point)
+
+for mesh_face in mesh_iter
+    GT.nodes(mesh_face)
+    GT.node_coordinates(mesh_face)
+    GT.num_nodes(mesh_face)
+    for mesh_point in GT.foreach_point(mesh_face)
+        GT.coordinate(mesh_point)
+        GT.coordinate(GT.value,mesh_point)
+        GT.coordinate(ForwardDiff.jacobian,mesh_point)
+        GT.weight(mesh_point)
+    end
+end
+
 f_l_x = GT.node_coordinate_accessor(mesh,2)
 @show f_l_x(2)(1)
 

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -70,6 +70,7 @@ end
 mesh_iter = GT.foreach_face(mesh,dΛ)
 mesh_iter = GT.compute(GT.value,mesh_iter)
 mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
+mesh_iter = GT.compute(GT.unit_normal,mesh_iter)
 mesh_dface = mesh_iter[2]
 mesh_Dface = GT.at_face_around(mesh_dface,2)
 @show GT.nodes(mesh_Dface)
@@ -78,6 +79,7 @@ mesh_point = GT.at_point(mesh_Dface,1)
 @show GT.coordinate(GT.value,mesh_point)
 @show GT.coordinate(ForwardDiff.jacobian,mesh_point)
 @show GT.weight(mesh_point)
+@show GT.unit_normal(mesh_point)
 
 for mesh_dface in mesh_iter
     for mesh_Dface in GT.foreach_face_around(mesh_dface)
@@ -89,9 +91,12 @@ for mesh_dface in mesh_iter
             GT.coordinate(GT.value,mesh_point)
             GT.coordinate(ForwardDiff.jacobian,mesh_point)
             GT.weight(mesh_point)
+            GT.unit_normal(mesh_point)
         end
     end
 end
+
+xxx
 
 f_l_x = GT.node_coordinate_accessor(mesh,2)
 @show f_l_x(2)(1)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -67,6 +67,32 @@ for mesh_face in mesh_iter
     end
 end
 
+mesh_iter = GT.foreach_face(mesh,dΛ)
+mesh_iter = GT.compute(GT.value,mesh_iter)
+mesh_iter = GT.compute(ForwardDiff.gradient,mesh_iter)
+mesh_dface = mesh_iter[2]
+mesh_Dface = GT.at_face_around(mesh_dface,2)
+@show GT.nodes(mesh_Dface)
+@show GT.node_coordinates(mesh_Dface)
+mesh_point = GT.at_point(mesh_Dface,1)
+@show GT.coordinate(GT.value,mesh_point)
+@show GT.coordinate(ForwardDiff.jacobian,mesh_point)
+@show GT.weight(mesh_point)
+
+for mesh_dface in mesh_iter
+    for mesh_Dface in GT.foreach_face_around(mesh_dface)
+        GT.nodes(mesh_Dface)
+        GT.node_coordinates(mesh_Dface)
+        GT.num_nodes(mesh_Dface)
+        for mesh_point in GT.foreach_point(mesh_Dface)
+            GT.coordinate(mesh_point)
+            GT.coordinate(GT.value,mesh_point)
+            GT.coordinate(ForwardDiff.jacobian,mesh_point)
+            GT.weight(mesh_point)
+        end
+    end
+end
+
 f_l_x = GT.node_coordinate_accessor(mesh,2)
 @show f_l_x(2)(1)
 


### PR DESCRIPTION
This adds the new iterator design which will eventually replace the current accessor functions.

Integrating a function `f` over a domain `Ω ` is done with the new API as follows

```julia
degree = 3
dΩ = GT.quadrature(Ω,degree)

s = 0.0
for dΩ_face in GT.foreach_face(dΩ)
    for dΩ_point in GT.foreach_point(dΩ)
        x = GT.coordinate(dΩ_point)
        dV = GT.weight(dΩ_point)
        s += f(x)*dV
    end
end
```

See the assembly of a Laplace matrix with the new API here

https://github.com/GalerkinToolkit/GalerkinToolkit.jl/blob/74cdc8fd2817a36b73cfddc41ee06c4c842fb327/GalerkinToolkitExamples/src/poisson.jl#L246

cc @katikov 