### PR TITLE
Getting rid of NamedTuples in accessors and more.

### DIFF
--- a/docs/src/src_jl/example_hello_world_dg.jl
+++ b/docs/src/src_jl/example_hello_world_dg.jl
@@ -40,13 +40,15 @@ h_Γd = GT.face_diameter_field(Γd)
 
 #Functions
 const ∇ = ForwardDiff.gradient
-g = GT.analytical_field(sum,Ω)
-f = GT.analytical_field(x->0,Ω)
+const g = GT.analytical_field(sum,Ω)
+const f = GT.analytical_field(x->0,Ω)
 mean(f,u,x) = 0.5*(f(u[1],x)+f(u[2],x))
 jump(u,n,x) = u[2](x)*n[2](x) + u[1](x)*n[1](x)
 
 #Interpolation
 k = 1
+const γ0 = k*(k+1)/10
+γ = GT.uniform_quantity(γ0)
 V = GT.lagrange_space(Ω,k;continuous=false)
 
 #Integration
@@ -56,7 +58,6 @@ dΛ = GT.quadrature(Λ,degree)
 dΓd = GT.quadrature(Γd,degree)
 
 #Weak form
-γ = GT.uniform_quantity(k*(k+1)/10)
 a = (u,v) -> begin
     #Laplace operator
     GT.∫(dΩ) do x
@@ -105,4 +106,203 @@ Makie.hidedecorations!(ax)
 GT.makie_surfaces!(Λ;color=x->mean(GT.value,uh,x))
 FileIO.save(joinpath(@__DIR__,"fig_hello_world_dg_1.png"),Makie.current_figure()) # hide
 nothing # hide
+
+
+# ## Explicit integration loops
+#
+# This other code version implements the integration loops manually instead of relying on the underlying automatic code generation.
+
+function assemble_Ω!(A_alloc,b_alloc,V,dΩ)
+
+    #Temporaries
+    n = GT.max_num_reference_dofs(V)
+    T = Float64
+    Auu = zeros(T,n,n)
+    bu = zeros(T,n)
+
+    #Loop over bulk faces
+    tabulate = (∇,GT.value)
+    compute=(GT.coordinate,)
+    for V_face in GT.each_face(V,dΩ;tabulate,compute)
+        dofs = GT.dofs(V_face)
+        ndofs = length(dofs)
+        fill!(Auu,zero(T))
+        fill!(bu,zero(T))
+        for V_point in GT.each_point(V_face)
+            dV = GT.weight(V_point)
+            dof_∇s = GT.shape_functions(∇,V_point)
+            dof_s = GT.shape_functions(GT.value,V_point)
+            x = GT.coordinate(V_point)
+            fx = f.definition(x)
+            for i in 1:ndofs
+                v = dof_s[i]
+                bu[i] += v*fx*dV
+            end
+            for j in 1:ndofs
+                ∇u = dof_∇s[j]
+                for i in 1:ndofs
+                    ∇v = dof_∇s[i]
+                    Auu[i,j] += ∇v⋅∇u*dV
+                end
+            end
+        end
+        GT.contribute!(A_alloc,Auu,dofs,dofs)
+        GT.contribute!(b_alloc,bu,dofs)
+    end
+
+end
+
+function assemble_Λ!(A_alloc,V,dΛ)
+
+    #Temporaries
+    n = GT.max_num_reference_dofs(V)
+    T = Float64
+    Auu = zeros(T,n,n)
+
+    #Loop over skeleton faces
+    tabulate = (∇,GT.value)
+    compute=(GT.unit_normal,)
+    V_dfaces = GT.each_face(V,dΛ;tabulate,compute)
+    dΛ_dfaces = GT.each_face(dΛ)
+    for (dΛ_dface,V_dface) in zip(dΛ_dfaces,V_dfaces)
+        h = GT.diameter(dΛ_dface)
+        dΛ_points = GT.each_point(dΛ_dface)
+        for V_Dface_i in GT.each_face_around(V_dface)
+            dofs_i = GT.dofs(V_Dface_i)
+            ndofs_i = length(dofs_i)
+            V_points_i = GT.each_point(V_Dface_i)
+            for V_Dface_j in GT.each_face_around(V_dface)
+                V_points_j = GT.each_point(V_Dface_j)
+                dofs_j = GT.dofs(V_Dface_j)
+                ndofs_j = length(dofs_j)
+                fill!(Auu,zero(T))
+                for (dΛ_point,V_point_i,V_point_j) in zip(dΛ_points,V_points_i,V_points_j)
+                    dS = GT.weight(dΛ_point)
+                    s_i = GT.shape_functions(GT.value,V_point_i)
+                    s_j = GT.shape_functions(GT.value,V_point_j)
+                    ∇s_i = GT.shape_functions(∇,V_point_i)
+                    ∇s_j = GT.shape_functions(∇,V_point_j)
+                    n_i = GT.unit_normal(V_point_i)
+                    n_j = GT.unit_normal(V_point_j)
+                    for j in 1:ndofs_j
+                        for i in 1:ndofs_i
+                            jump_jump = (γ0/h)*(s_i[i]*n_i)⋅(s_j[j]*n_j)
+                            jump_mean = (s_i[i]*n_i)⋅(0.5*∇s_j[j])
+                            mean_jump = (0.5*∇s_i[i])⋅(s_j[j]*n_j)
+                            Auu[i,j] += (jump_jump - jump_mean - mean_jump)*dS
+                        end
+                    end
+                end
+                GT.contribute!(A_alloc,Auu,dofs_i,dofs_j)
+            end
+        end
+    end
+
+end
+
+function assemble_Γd!(A_alloc,b_alloc,V,dΓd)
+
+    #Temporaries
+    n = GT.max_num_reference_dofs(V)
+    T = Float64
+    Auu = zeros(T,n,n)
+    bu = zeros(T,n)
+
+    #Loop over Dirichlet boundary
+    dΓd_dfaces = GT.each_face(dΓd)
+    tabulate = (∇,GT.value)
+    compute=(GT.unit_normal,)
+    V_dfaces = GT.each_face(V,dΓd;tabulate,compute)
+    for (V_dface,dΓd_dface) in zip(V_dfaces,dΓd_dfaces)
+        dofs = GT.dofs(V_dface)
+        ndofs = length(dofs)
+        V_points = GT.each_point(V_dface)
+        h = GT.diameter(dΓd_dface)
+        dΓd_points = GT.each_point(dΓd_dface)
+        fill!(Auu,zero(T))
+        fill!(bu,zero(T))
+        for (V_point,dΓd_point) in zip(V_points,dΓd_points)
+            dS = GT.weight(dΓd_point)
+            x = GT.coordinate(dΓd_point)
+            dof_s = GT.shape_functions(GT.value,V_point)
+            dof_∇s = GT.shape_functions(∇,V_point)
+            n = GT.unit_normal(V_point)
+            gx = g.definition(x)
+            for i in 1:ndofs
+                ∇v = dof_∇s[i]
+                v = dof_s[i]
+                bu[i] += ((γ0/h)*v*gx - n⋅∇v*gx)*dS
+            end
+            for j in 1:ndofs
+                ∇u = dof_∇s[j]
+                u = dof_s[j]
+                for i in 1:ndofs
+                    ∇v = dof_∇s[i]
+                    v = dof_s[i]
+                    Auu[i,j] += ((γ0/h)*v*u - v*n⋅∇u - n⋅∇v*u)*dS
+                end
+            end
+        end
+        GT.contribute!(A_alloc,Auu,dofs,dofs)
+        GT.contribute!(b_alloc,bu,dofs)
+    end
+
+end
+
+function integrate_l2_error(g,uh,dΩ)
+
+    #Iterators to the quantities on the
+    #integration points
+    tabulate = (GT.value,)
+    compute = (GT.coordinate,)
+    uh_faces = GT.each_face(uh,dΩ;tabulate,compute)
+
+    #Numerical integration loop
+    s = 0.0
+    for uh_face in uh_faces
+        for uh_point in GT.each_point(uh_face)
+
+            #Get quantities at current integration point
+            x = GT.coordinate(uh_point)
+            dV = GT.weight(uh_point)
+            uhx = GT.field(GT.value,uh_point)
+
+            #Add contribution
+            s += abs2(uhx-g.definition(x))*dV
+        end
+    end
+
+    #Compute the l2 norm
+    el2 = sqrt(s)
+end
+
+#Allocate matrix for free columns
+T = Float64
+A_alloc = GT.allocate_matrix(T,V,V,Ω,Λ,Γd)
+b_alloc = GT.allocate_vector(T,V,Ω,Γd)
+
+#Fill allocations with the function we wrote above
+assemble_Ω!(A_alloc,b_alloc,V,dΩ)
+assemble_Λ!(A_alloc,V,dΛ)
+assemble_Γd!(A_alloc,b_alloc,V,dΓd)
+
+#Compress matrix into the final format
+A = GT.compress(A_alloc)
+b = GT.compress(b_alloc)
+
+#Build the linear system
+p = LinearSolve.LinearProblem(A,b)
+
+#Solve the problem
+sol = LinearSolve.solve(p)
+uh = GT.solution_field(V,sol)
+
+#Integrate the error l2 norm
+#with the function we wrote above
+el2 = integrate_l2_error(g,uh,dΩ)
+@assert el2 < 1.0e-9
+nothing # hide
+
+
+
 

--- a/src/accessors.jl
+++ b/src/accessors.jl
@@ -719,6 +719,22 @@ function shape_functions(a::MeshAccessor)
     shape_functions(space_accessor)
 end
 
+function diameter(a::MeshAccessor)
+    nodes = GT.nodes(a)
+    mesh = GT.mesh(a.space_accessor.space)
+    node_x = GT.node_coordinates(mesh)
+    nnodes = length(nodes)
+    diam = zero(eltype(eltype(node_x)))
+    for i in 1:nnodes
+        xi = node_x[nodes[i]]
+        for j in 1:nnodes
+            xj = node_x[nodes[j]]
+            diam = max(diam,norm(xi-xj))
+        end
+    end
+    diam
+end
+
 function num_points(a::MeshAccessor)
     (;space_accessor) = a
     num_points(space_accessor)

--- a/test/accessors_tests.jl
+++ b/test/accessors_tests.jl
@@ -29,6 +29,7 @@ mesh_faces = GT.each_face(mesh_dΩ)
 mesh_face = mesh_faces[2]
 @show GT.nodes(mesh_face)
 @show GT.node_coordinates(mesh_face)
+@show GT.diameter(mesh_face)
 mesh_points = GT.each_point(mesh_face)
 mesh_point = mesh_points[1]
 @show GT.coordinate(GT.value,mesh_point)


### PR DESCRIPTION
@katikov this pretty much finishes the new accessors.

I checked that they are as fast as working with the plain arrays directly for a Laplace matrix.